### PR TITLE
fix: JIRA tools selectables as other tools

### DIFF
--- a/libs/agent/agent.service.ts
+++ b/libs/agent/agent.service.ts
@@ -257,10 +257,8 @@ ${agentDocs}
           })
         )
       : undefined
-
-    const syncTools = this.toolbox.getTools({ context, integrations, agentName: def.name })
-    const asyncTools = await this.toolbox.getAsyncTools(context)
-    const toolset = new ToolSet([...syncTools, ...asyncTools])
+    const syncTools = await this.toolbox.getTools({ context, integrations, agentName: def.name })
+    const toolset = new ToolSet([...syncTools])
     const agent = new Agent(def, aiClient, toolset)
     this.agents.set(agent.name.toLowerCase(), agent)
   }

--- a/libs/integration/ai/ai.tools.ts
+++ b/libs/integration/ai/ai.tools.ts
@@ -18,7 +18,7 @@ export class AiTools extends AssistantToolFactory {
     return true
   }
 
-  protected buildTools(context: CommandContext): CodayTool[] {
+  protected async buildTools(context: CommandContext): Promise<CodayTool[]> {
     const result: CodayTool[] = []
 
     if (!context.oneshot) {

--- a/libs/integration/assistant-tool-factory.ts
+++ b/libs/integration/assistant-tool-factory.ts
@@ -12,13 +12,10 @@ export abstract class AssistantToolFactory {
 
   protected abstract hasChanged(context: CommandContext): boolean
 
-  protected abstract buildTools(context: CommandContext, agentName: string): CodayTool[]
+  protected abstract buildTools(context: CommandContext, agentName: string): Promise<CodayTool[]>
 
-  getTools(context: CommandContext, toolNames: string[], agentName: string): CodayTool[] {
-    if (!this.lastToolInitContext || this.hasChanged(context)) {
-      this.lastToolInitContext = context
-      this.tools = this.buildTools(context, agentName)
-    }
+  async getTools(context: CommandContext, toolNames: string[], agentName: string): Promise<CodayTool[]> {
+    this.tools = await this.buildTools(context, agentName)
     return this.tools.filter((tool) => !toolNames || !toolNames.length || toolNames.includes(tool.function.name))
   }
 }

--- a/libs/integration/confluence/confluence.tools.ts
+++ b/libs/integration/confluence/confluence.tools.ts
@@ -19,7 +19,7 @@ export class ConfluenceTools extends AssistantToolFactory {
     return this.lastToolInitContext?.project.root !== context.project.root
   }
 
-  protected buildTools(): CodayTool[] {
+  protected async buildTools(): Promise<CodayTool[]> {
     const result: CodayTool[] = []
     if (!this.integrationService.hasIntegration('CONFLUENCE')) {
       return result

--- a/libs/integration/file/file.tools.ts
+++ b/libs/integration/file/file.tools.ts
@@ -49,7 +49,7 @@ export class FileTools extends AssistantToolFactory {
     return true
   }
 
-  protected buildTools(context: CommandContext): CodayTool[] {
+  protected async buildTools(context: CommandContext): Promise<CodayTool[]> {
     const result: CodayTool[] = []
 
     // Only add write/delete tools if not in read-only mode

--- a/libs/integration/git/git.tools.ts
+++ b/libs/integration/git/git.tools.ts
@@ -25,7 +25,7 @@ export class GitTools extends AssistantToolFactory {
     return this.lastToolInitContext?.project.root !== context.project.root
   }
 
-  protected buildTools(context: CommandContext): CodayTool[] {
+  protected async buildTools(context: CommandContext): Promise<CodayTool[]> {
     const result: CodayTool[] = []
 
     if (!this.integrationService.hasIntegration('GIT')) {

--- a/libs/integration/gitlab/gitlab.tools.ts
+++ b/libs/integration/gitlab/gitlab.tools.ts
@@ -23,7 +23,7 @@ export class GitLabTools extends AssistantToolFactory {
     return this.lastToolInitContext?.project.root !== context.project.root
   }
 
-  protected buildTools(): CodayTool[] {
+  protected async buildTools(): Promise<CodayTool[]> {
     const result: CodayTool[] = []
     const gitlab = this.integrationService.getIntegration('GITLAB')
     if (!gitlab) {

--- a/libs/integration/jira/jira.tools.ts
+++ b/libs/integration/jira/jira.tools.ts
@@ -1,14 +1,15 @@
 import { IntegrationService } from '../../service/integration.service'
 import { CommandContext, Interactor } from '../../model'
-import { CodayTool } from '../assistant-tool-factory'
+import { AssistantToolFactory, CodayTool } from '../assistant-tool-factory'
 import { FunctionTool } from '../types'
 import { createJiraFieldMapping } from './jira-field-mapper'
-import { AsyncAssistantToolFactory } from '../async-assistant-tool-factory'
 import { searchJiraIssuesWithAI } from './search-jira-issues'
 import { addJiraComment } from './add-jira-comment'
 import { retrieveJiraIssue } from './retrieve-jira-issue'
 
-export class JiraTools extends AsyncAssistantToolFactory {
+export class JiraTools extends AssistantToolFactory {
+  name = 'JIRA'
+
   constructor(
     interactor: Interactor,
     private integrationService: IntegrationService
@@ -20,7 +21,7 @@ export class JiraTools extends AsyncAssistantToolFactory {
     return this.lastToolInitContext?.project.root !== context.project.root
   }
 
-  protected async buildAsyncTools(context: CommandContext): Promise<CodayTool[]> {
+  protected async buildTools(context: CommandContext): Promise<CodayTool[]> {
     const result: CodayTool[] = []
     if (!this.integrationService.hasIntegration('JIRA')) {
       return result

--- a/libs/integration/memory.tools.ts
+++ b/libs/integration/memory.tools.ts
@@ -20,7 +20,7 @@ export class MemoryTools extends AssistantToolFactory {
     return context.project.name !== this.lastToolInitContext?.project.name
   }
 
-  protected buildTools(context: CommandContext, agentName: string): CodayTool[] {
+  protected async buildTools(context: CommandContext, agentName: string): Promise<CodayTool[]> {
     const result: CodayTool[] = []
 
     const memorize = async ({ title, content, level }: { title: string; content: string; level: string }) => {

--- a/libs/integration/projectScriptsTools.ts
+++ b/libs/integration/projectScriptsTools.ts
@@ -16,7 +16,7 @@ export class ProjectScriptsTools extends AssistantToolFactory {
     return this.lastToolInitContext?.project.scripts !== context.project.scripts
   }
 
-  protected buildTools(context: CommandContext): CodayTool[] {
+  protected async buildTools(context: CommandContext): Promise<CodayTool[]> {
     const result: CodayTool[] = []
 
     const scripts: Scripts | undefined = context.project.scripts

--- a/libs/integration/toolbox.ts
+++ b/libs/integration/toolbox.ts
@@ -1,4 +1,4 @@
-import { CommandContext, Interactor } from '../model'
+import { Interactor } from '../model'
 import { AiTools } from './ai/ai.tools'
 import { FileTools } from './file/file.tools'
 import { JiraTools } from './jira/jira.tools'
@@ -8,14 +8,12 @@ import { GitLabTools } from './gitlab/gitlab.tools'
 import { MemoryTools } from './memory.tools'
 import { AssistantToolFactory, CodayTool } from './assistant-tool-factory'
 import { ConfluenceTools } from './confluence/confluence.tools'
-import { AsyncAssistantToolFactory } from './async-assistant-tool-factory'
 import { CodayServices } from '../coday-services'
 import { AgentService } from '../agent'
 import { GetToolsInput } from './types'
 
 export class Toolbox {
   private toolFactories: AssistantToolFactory[]
-  private asyncToolFactories: AsyncAssistantToolFactory[]
   private tools: CodayTool[] = []
 
   constructor(interactor: Interactor, services: CodayServices, agentService: AgentService) {
@@ -27,23 +25,18 @@ export class Toolbox {
       new GitLabTools(interactor, services.integration),
       new MemoryTools(interactor, services.memory),
       new ConfluenceTools(interactor, services.integration),
+      new JiraTools(interactor, services.integration),
     ]
-    this.asyncToolFactories = [new JiraTools(interactor, services.integration)]
   }
 
-  getTools(input: GetToolsInput): CodayTool[] {
+  async getTools(input: GetToolsInput): Promise<CodayTool[]> {
     const { context, integrations, agentName } = input
-    this.tools = this.toolFactories
-      .filter((factory) => !integrations || integrations.has(factory.name))
-      .flatMap((factory) => factory.getTools(context, integrations?.get(factory.name) ?? [], agentName))
-    return this.tools
-  }
-
-  async getAsyncTools(context: CommandContext): Promise<CodayTool[]> {
-    const asyncTools = await Promise.all(
-      this.asyncToolFactories.map((asyncFactory) => asyncFactory.getAsyncTools(context))
-    )
-    this.tools = asyncTools.flat()
+    const filteredFactories = this.toolFactories.filter((factory) => !integrations || integrations.has(factory.name))
+    this.tools = (
+      await Promise.all(
+        filteredFactories.map((factory) => factory.getTools(context, integrations?.get(factory.name) ?? [], agentName))
+      )
+    ).flat()
     return this.tools
   }
 }


### PR DESCRIPTION
JIRA tools were async at build, now all tools are async and lifecycle is simplified