### PR TITLE
feat: add web UI options

### DIFF
--- a/apps/web/client/app.ts
+++ b/apps/web/client/app.ts
@@ -145,10 +145,53 @@ components.forEach((c) => {
 const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
 const optionsPanel = document.getElementById('options-panel') as HTMLDivElement;
 const enterToSendToggle = document.getElementById('enter-to-send-toggle') as HTMLInputElement;
+const themeLight = document.getElementById('theme-light') as HTMLInputElement;
+const themeDark = document.getElementById('theme-dark') as HTMLInputElement;
+const themeSystem = document.getElementById('theme-system') as HTMLInputElement;
 
 // Set initial toggle state based on stored preference
 const useEnterToSend = getPreference('useEnterToSend', false);
 enterToSendToggle.checked = useEnterToSend !== undefined ? useEnterToSend : false;
+
+// Apply theme based on preference or system setting
+function applyTheme() {
+  const savedTheme = getPreference<string>('theme', 'light');
+  
+  // Update radio buttons to match saved preference
+  themeLight.checked = savedTheme === 'light';
+  themeDark.checked = savedTheme === 'dark';
+  themeSystem.checked = savedTheme === 'system';
+  
+  if (savedTheme === 'system') {
+    // Check system preference
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (prefersDark) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
+  } else if (savedTheme === 'dark') {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  } else {
+    // Light theme is default
+    document.documentElement.removeAttribute('data-theme');
+  }
+}
+
+// Apply theme on page load
+applyTheme();
+
+// Listen for system theme changes
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+  const savedTheme = getPreference<string>('theme', 'light');
+  if (savedTheme === 'system') {
+    if (e.matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
+  }
+});
 
 // Toggle panel visibility when options button is clicked
 optionsButton.addEventListener('click', (event) => {
@@ -168,6 +211,17 @@ document.addEventListener('click', (event) => {
 // Save preference when toggle changes
 enterToSendToggle.addEventListener('change', () => {
   setPreference('useEnterToSend', enterToSendToggle.checked);
+});
+
+// Handle theme selection
+document.querySelectorAll('input[name="theme"]').forEach((input) => {
+  input.addEventListener('change', (e) => {
+    const target = e.target as HTMLInputElement;
+    if (target.checked) {
+      setPreference('theme', target.value);
+      applyTheme();
+    }
+  });
 });
 
 // Initial setup

--- a/apps/web/client/app.ts
+++ b/apps/web/client/app.ts
@@ -111,7 +111,9 @@ function setupEventSource() {
         components.forEach((c) =>
           c.handle(
             new ErrorEvent({
-              error: new Error(`Connection lost. Attempting to reconnect (${reconnectAttempts + 1}/${MAX_RECONNECT_ATTEMPTS})...`),
+              error: new Error(
+                `Connection lost. Attempting to reconnect (${reconnectAttempts + 1}/${MAX_RECONNECT_ATTEMPTS})...`
+              ),
             })
           )
         )
@@ -139,90 +141,87 @@ components.forEach((c) => {
   }
 })
 
-
-
 // Simple options panel setup
-const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
-const optionsPanel = document.getElementById('options-panel') as HTMLDivElement;
-const enterToSendToggle = document.getElementById('enter-to-send-toggle') as HTMLInputElement;
-const themeLight = document.getElementById('theme-light') as HTMLInputElement;
-const themeDark = document.getElementById('theme-dark') as HTMLInputElement;
-const themeSystem = document.getElementById('theme-system') as HTMLInputElement;
+const optionsButton = document.getElementById('options-button') as HTMLButtonElement
+const optionsPanel = document.getElementById('options-panel') as HTMLDivElement
+const enterToSendToggle = document.getElementById('enter-to-send-toggle') as HTMLInputElement
+const themeLight = document.getElementById('theme-light') as HTMLInputElement
+const themeDark = document.getElementById('theme-dark') as HTMLInputElement
+const themeSystem = document.getElementById('theme-system') as HTMLInputElement
 
 // Set initial toggle state based on stored preference
-const useEnterToSend = getPreference('useEnterToSend', false);
-enterToSendToggle.checked = useEnterToSend !== undefined ? useEnterToSend : false;
+const useEnterToSend = getPreference('useEnterToSend', false)
+enterToSendToggle.checked = useEnterToSend !== undefined ? useEnterToSend : false
 
 // Apply theme based on preference or system setting
 function applyTheme() {
-  const savedTheme = getPreference<string>('theme', 'light');
-  
+  const savedTheme = getPreference<string>('theme', 'light')
+
   // Update radio buttons to match saved preference
-  themeLight.checked = savedTheme === 'light';
-  themeDark.checked = savedTheme === 'dark';
-  themeSystem.checked = savedTheme === 'system';
-  
+  themeLight.checked = savedTheme === 'light'
+  themeDark.checked = savedTheme === 'dark'
+  themeSystem.checked = savedTheme === 'system'
+
   if (savedTheme === 'system') {
     // Check system preference
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
     if (prefersDark) {
-      document.documentElement.setAttribute('data-theme', 'dark');
+      document.documentElement.setAttribute('data-theme', 'dark')
     } else {
-      document.documentElement.removeAttribute('data-theme');
+      document.documentElement.removeAttribute('data-theme')
     }
   } else if (savedTheme === 'dark') {
-    document.documentElement.setAttribute('data-theme', 'dark');
+    document.documentElement.setAttribute('data-theme', 'dark')
   } else {
     // Light theme is default
-    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-theme')
   }
 }
 
 // Apply theme on page load
-applyTheme();
+applyTheme()
 
 // Listen for system theme changes
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-  const savedTheme = getPreference<string>('theme', 'light');
+  const savedTheme = getPreference<string>('theme', 'light')
   if (savedTheme === 'system') {
     if (e.matches) {
-      document.documentElement.setAttribute('data-theme', 'dark');
+      document.documentElement.setAttribute('data-theme', 'dark')
     } else {
-      document.documentElement.removeAttribute('data-theme');
+      document.documentElement.removeAttribute('data-theme')
     }
   }
-});
+})
 
 // Toggle panel visibility when options button is clicked
 optionsButton.addEventListener('click', (event) => {
-  event.stopPropagation();
-  const isVisible = optionsPanel.style.display === 'block';
-  optionsPanel.style.display = isVisible ? 'none' : 'block';
-});
+  event.stopPropagation()
+  const isVisible = optionsPanel.style.display === 'block'
+  optionsPanel.style.display = isVisible ? 'none' : 'flex'
+})
 
 // Close panel when clicking elsewhere
 document.addEventListener('click', (event) => {
-  if (!optionsPanel.contains(event.target as Node) && 
-      event.target !== optionsButton) {
-    optionsPanel.style.display = 'none';
+  if (!optionsPanel.contains(event.target as Node) && event.target !== optionsButton) {
+    optionsPanel.style.display = 'none'
   }
-});
+})
 
 // Save preference when toggle changes
 enterToSendToggle.addEventListener('change', () => {
-  setPreference('useEnterToSend', enterToSendToggle.checked);
-});
+  setPreference('useEnterToSend', enterToSendToggle.checked)
+})
 
 // Handle theme selection
 document.querySelectorAll('input[name="theme"]').forEach((input) => {
   input.addEventListener('change', (e) => {
-    const target = e.target as HTMLInputElement;
+    const target = e.target as HTMLInputElement
     if (target.checked) {
-      setPreference('theme', target.value);
-      applyTheme();
+      setPreference('theme', target.value)
+      applyTheme()
     }
-  });
-});
+  })
+})
 
 // Initial setup
 setupEventSource()

--- a/apps/web/client/app.ts
+++ b/apps/web/client/app.ts
@@ -149,6 +149,30 @@ const themeLight = document.getElementById('theme-light') as HTMLInputElement
 const themeDark = document.getElementById('theme-dark') as HTMLInputElement
 const themeSystem = document.getElementById('theme-system') as HTMLInputElement
 
+// Detect operating system for keyboard shortcuts
+function detectOS(): 'mac' | 'non-mac' {
+  return navigator.platform.toLowerCase().includes('mac') ? 'mac' : 'non-mac';
+}
+
+// Update the send button label based on preferences and OS
+function updateSendButtonLabel() {
+  const useEnterToSend = getPreference<boolean>('useEnterToSend', false);
+  const os = detectOS();
+  const submitButton = document.querySelector('.submit') as HTMLButtonElement;
+  
+  if (!submitButton) return;
+  
+  if (useEnterToSend) {
+    submitButton.innerHTML = 'SEND <br/><br/>enter';
+  } else {
+    if (os === 'mac') {
+      submitButton.innerHTML = 'SEND <br/><br/>⌘ + enter';
+    } else {
+      submitButton.innerHTML = 'SEND <br/><br/>Ctrl + enter';
+    }
+  }
+}
+
 // Set initial toggle state based on stored preference
 const useEnterToSend = getPreference('useEnterToSend', false)
 enterToSendToggle.checked = useEnterToSend !== undefined ? useEnterToSend : false
@@ -209,7 +233,8 @@ document.addEventListener('click', (event) => {
 
 // Save preference when toggle changes
 enterToSendToggle.addEventListener('change', () => {
-  setPreference('useEnterToSend', enterToSendToggle.checked)
+  setPreference('useEnterToSend', enterToSendToggle.checked);
+  updateSendButtonLabel();
 })
 
 // Handle theme selection
@@ -222,6 +247,9 @@ document.querySelectorAll('input[name="theme"]').forEach((input) => {
     }
   })
 })
+
+// Update send button label based on preferences and OS
+updateSendButtonLabel();
 
 // Initial setup
 setupEventSource()

--- a/apps/web/client/app.ts
+++ b/apps/web/client/app.ts
@@ -149,30 +149,6 @@ const themeLight = document.getElementById('theme-light') as HTMLInputElement
 const themeDark = document.getElementById('theme-dark') as HTMLInputElement
 const themeSystem = document.getElementById('theme-system') as HTMLInputElement
 
-// Detect operating system for keyboard shortcuts
-function detectOS(): 'mac' | 'non-mac' {
-  return navigator.platform.toLowerCase().includes('mac') ? 'mac' : 'non-mac';
-}
-
-// Update the send button label based on preferences and OS
-function updateSendButtonLabel() {
-  const useEnterToSend = getPreference<boolean>('useEnterToSend', false);
-  const os = detectOS();
-  const submitButton = document.querySelector('.submit') as HTMLButtonElement;
-  
-  if (!submitButton) return;
-  
-  if (useEnterToSend) {
-    submitButton.innerHTML = 'SEND <br/><br/>enter';
-  } else {
-    if (os === 'mac') {
-      submitButton.innerHTML = 'SEND <br/><br/>⌘ + enter';
-    } else {
-      submitButton.innerHTML = 'SEND <br/><br/>Ctrl + enter';
-    }
-  }
-}
-
 // Set initial toggle state based on stored preference
 const useEnterToSend = getPreference('useEnterToSend', false)
 enterToSendToggle.checked = useEnterToSend !== undefined ? useEnterToSend : false
@@ -234,7 +210,6 @@ document.addEventListener('click', (event) => {
 // Save preference when toggle changes
 enterToSendToggle.addEventListener('change', () => {
   setPreference('useEnterToSend', enterToSendToggle.checked);
-  updateSendButtonLabel();
 })
 
 // Handle theme selection
@@ -247,9 +222,6 @@ document.querySelectorAll('input[name="theme"]').forEach((input) => {
     }
   })
 })
-
-// Update send button label based on preferences and OS
-updateSendButtonLabel();
 
 // Initial setup
 setupEventSource()

--- a/apps/web/client/app.ts
+++ b/apps/web/client/app.ts
@@ -4,6 +4,7 @@ import { ChatHistoryComponent } from './chat-history/chat-history.component'
 import { buildCodayEvent, CodayEvent, ErrorEvent } from '@coday/shared/coday-events'
 import { CodayEventHandler } from './utils/coday-event-handler'
 import { HeaderComponent } from './header/header.component'
+import { getPreference, setPreference } from './utils/preferences'
 
 // Debug logging function
 function debugLog(context: string, ...args: any[]) {
@@ -137,6 +138,37 @@ components.forEach((c) => {
     originalHandle(event)
   }
 })
+
+
+
+// Simple options panel setup
+const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
+const optionsPanel = document.getElementById('options-panel') as HTMLDivElement;
+const enterToSendToggle = document.getElementById('enter-to-send-toggle') as HTMLInputElement;
+
+// Set initial toggle state based on stored preference
+const useEnterToSend = getPreference('useEnterToSend', false);
+enterToSendToggle.checked = useEnterToSend !== undefined ? useEnterToSend : false;
+
+// Toggle panel visibility when options button is clicked
+optionsButton.addEventListener('click', (event) => {
+  event.stopPropagation();
+  const isVisible = optionsPanel.style.display === 'block';
+  optionsPanel.style.display = isVisible ? 'none' : 'block';
+});
+
+// Close panel when clicking elsewhere
+document.addEventListener('click', (event) => {
+  if (!optionsPanel.contains(event.target as Node) && 
+      event.target !== optionsButton) {
+    optionsPanel.style.display = 'none';
+  }
+});
+
+// Save preference when toggle changes
+enterToSendToggle.addEventListener('change', () => {
+  setPreference('useEnterToSend', enterToSendToggle.checked);
+});
 
 // Initial setup
 setupEventSource()

--- a/apps/web/client/chat-history/chat-history.component.ts
+++ b/apps/web/client/chat-history/chat-history.component.ts
@@ -34,8 +34,8 @@ export class ChatHistoryComponent implements CodayEventHandler {
       this.addAnswer(event.answer, event.invite)
     }
     if (event instanceof ErrorEvent) {
-      const errorMessage = event.error instanceof Error ? event.error.message : String(event.error);
-      this.addError(errorMessage);
+      const errorMessage = event.error instanceof Error ? event.error.message : String(event.error)
+      this.addError(errorMessage)
     }
     if (event instanceof ThinkingEvent) {
       this.setThinking(true)
@@ -64,19 +64,19 @@ export class ChatHistoryComponent implements CodayEventHandler {
 
   addTechnical(text: string): void {
     const newEntry = this.createMessageElement(text, undefined)
-    newEntry.classList.add('technical', 'right')
+    newEntry.classList.add('technical', 'left')
     this.appendMessageElement(newEntry)
   }
 
   addText(text: string, speaker: string | undefined): void {
     const newEntry = this.createMessageElement(text, speaker)
-    newEntry.classList.add('text', 'right')
+    newEntry.classList.add('text', 'left')
     this.appendMessageElement(newEntry)
   }
 
   addAnswer(answer: string, speaker: string | undefined): void {
     const newEntry = this.createMessageElement(answer, speaker)
-    newEntry.classList.add('text', 'left')
+    newEntry.classList.add('text', 'right')
     this.appendMessageElement(newEntry)
   }
 
@@ -113,18 +113,18 @@ export class ChatHistoryComponent implements CodayEventHandler {
     this.setThinking(false)
     const errorEntry = document.createElement('div')
     errorEntry.classList.add('error-message')
-    
+
     // Create an error icon
     const errorIcon = document.createElement('span')
     errorIcon.textContent = '\u274c ' // Red X symbol
     errorIcon.classList.add('error-icon')
     errorEntry.appendChild(errorIcon)
-    
+
     // Create the error text
     const errorText = document.createElement('span')
     errorText.textContent = `Error: ${error}`
     errorEntry.appendChild(errorText)
-    
+
     // Add styling
     errorEntry.style.color = '#e74c3c' // Red color
     errorEntry.style.background = '#ffeeee' // Light red background
@@ -132,7 +132,7 @@ export class ChatHistoryComponent implements CodayEventHandler {
     errorEntry.style.margin = '10px 0'
     errorEntry.style.borderRadius = '4px'
     errorEntry.style.border = '1px solid #e74c3c'
-    
+
     this.chatHistory?.appendChild(errorEntry)
     this.scrollToBottom()
   }

--- a/apps/web/client/chat-history/chat-history.component.ts
+++ b/apps/web/client/chat-history/chat-history.component.ts
@@ -64,7 +64,7 @@ export class ChatHistoryComponent implements CodayEventHandler {
 
   addTechnical(text: string): void {
     const newEntry = this.createMessageElement(text, undefined)
-    newEntry.classList.add('technical', 'left')
+    newEntry.classList.add('technical')
     this.appendMessageElement(newEntry)
   }
 

--- a/apps/web/client/chat-history/chat-history.css
+++ b/apps/web/client/chat-history/chat-history.css
@@ -48,7 +48,7 @@
 }
 
 .technical {
-    align-self: flex-end;
+    align-self: flex-start;
     color: var(--color-text-secondary);
     font-style: italic;
 }

--- a/apps/web/client/chat-history/chat-history.css
+++ b/apps/web/client/chat-history/chat-history.css
@@ -16,7 +16,8 @@
 .message pre {
     white-space: pre-wrap;
     word-wrap: break-word;
-    background-color: var(--color-text);
+    background-color: var(--color-code-bg);
+    color: var(--color-text-inverse);
     border-radius: 0.3em;
     padding: 0.5em;
     border: 1px solid var(--color-text-secondary);

--- a/apps/web/client/chat-history/chat-history.css
+++ b/apps/web/client/chat-history/chat-history.css
@@ -1,121 +1,120 @@
 #chat-history {
-  flex-grow: 1;
-  overflow-y: auto;
-  padding: 1em;
-  display: flex;
-  flex-direction: column;
-  flex: 1;
+    flex-grow: 1;
+    overflow-y: auto;
+    padding: 1em;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
 }
 
 .message {
-  display: flex;
-  flex-direction: column;
-  word-wrap: break-word;
+    display: flex;
+    flex-direction: column;
+    word-wrap: break-word;
 }
 
 .message pre {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  background-color: #44475a;
-  border-radius: 0.3em;
-  padding: 0.5em;
-  border: 1px solid #6272a4;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    background-color: var(--color-text);
+    border-radius: 0.3em;
+    padding: 0.5em;
+    border: 1px solid var(--color-text-secondary);
 }
 
 .text {
-  background-color: #44475a;
-  color: #f8f8f2;
-  margin-bottom: 1em;
-  margin-top: 1em;
-  padding: 1em 1em 0em 2em;
-  border-radius: 0.5em;
-  box-shadow: 3px 4px 4px rgba(0, 0, 0, 0.2);
+    background-color: var(--color-message-ai);
+    color: var(--color-text);
+    margin-bottom: 1em;
+    margin-top: 1em;
+    padding: 1em 1em 0em 2em;
+    border-radius: 0.5em;
+    box-shadow: 3px 4px 4px rgba(0, 0, 0, 0.2);
 }
 
 .text.right {
-  align-self: flex-end;
-  margin-left: 5em;
-  background-color: #6272a4;
+    align-self: flex-end;
+    margin-left: 5em;
+    background-color: var(--color-message-user);
 }
 
 .text.left {
-  align-self: flex-start;
-  margin-right: 5em;
+    align-self: flex-start;
+    margin-right: 5em;
 }
 
 .text:last-child {
-  background-color: #44475a;
-  border: 1px solid #bd93f9;
+    border: 1px solid var(--color-primary);
 }
 
 .technical {
-  align-self: flex-end;
-  color: #6272a4;
-  font-style: italic;
+    align-self: flex-end;
+    color: var(--color-text-secondary);
+    font-style: italic;
 }
 
 .message .speaker {
-  font-weight: bold;
-  margin-left: -1em;
-  color: #ff79c6;
+    font-weight: bold;
+    margin-left: -1em;
+    color: var(--color-primary);
 }
 
 #thinking-dots {
-  order: 1;
-  visibility: hidden;
-  bottom: 0;
-  font-size: 2em;
-  color: #6272a4;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1em;
+    order: 1;
+    visibility: hidden;
+    bottom: 0;
+    font-size: 2em;
+    color: var(--color-text);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1em;
 }
 
 .stop-button {
-  cursor: pointer;
-  background: none;
-  border: none;
-  font-size: 0.8em;
-  padding: 0.2em 0.4em;
-  border-radius: 4px;
-  transition: background-color 0.2s;
-  color: #ff79c6;
+    cursor: pointer;
+    background: none;
+    border: none;
+    font-size: 0.8em;
+    padding: 0.2em 0.4em;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+    color: var(--color-primary);
 }
 
 .stop-button:hover {
-  background-color: #bd93f9;
-  color: #f8f8f2;
+    background-color: var(--color-bg);
+    color: var(--color-text);
 }
 
 #thinking-dots.visible {
-  visibility: visible;
-  opacity: 1;
+    visibility: visible;
+    opacity: 1;
 }
 
 .dots {
-  display: flex;
+    display: flex;
 }
 
 #thinking-dots span {
-  animation: blink 1.4s infinite both;
+    animation: blink 1.4s infinite both;
 }
 
 #thinking-dots span:nth-child(2) {
-  animation-delay: 0.2s;
+    animation-delay: 0.2s;
 }
 
 #thinking-dots span:nth-child(3) {
-  animation-delay: 0.4s;
+    animation-delay: 0.4s;
 }
 
 @keyframes blink {
-  0%,
-  80%,
-  100% {
-    opacity: 0;
-  }
-  40% {
-    opacity: 1;
-  }
+    0%,
+    80%,
+    100% {
+        opacity: 0;
+    }
+    40% {
+        opacity: 1;
+    }
 }

--- a/apps/web/client/chat-textarea/chat-textarea.component.ts
+++ b/apps/web/client/chat-textarea/chat-textarea.component.ts
@@ -9,6 +9,7 @@ export class ChatTextareaComponent implements CodayEventHandler {
   private expandToggle: HTMLButtonElement
   private submitButton: HTMLButtonElement
   private inviteEvent: InviteEvent | undefined
+  private readonly os: 'mac' | 'non-mac'
 
   /**
    * Detect operating system for keyboard shortcuts
@@ -22,14 +23,13 @@ export class ChatTextareaComponent implements CodayEventHandler {
    */
   private updateSendButtonLabel(): void {
     const useEnterToSend = getPreference<boolean>('useEnterToSend', false)
-    const os = this.detectOS()
     
     if (!this.submitButton) return
     
     if (useEnterToSend) {
       this.submitButton.innerHTML = 'SEND <br/><br/>enter'
     } else {
-      if (os === 'mac') {
+      if (this.os === 'mac') {
         this.submitButton.innerHTML = 'SEND <br/><br/>⌘ + enter'
       } else {
         this.submitButton.innerHTML = 'SEND <br/><br/>Ctrl + enter'
@@ -38,6 +38,9 @@ export class ChatTextareaComponent implements CodayEventHandler {
   }
 
   constructor(private postEvent: (event: CodayEvent) => Promise<Response>) {
+    // Detect OS once during initialization
+    this.os = this.detectOS()
+    
     this.chatForm = document.getElementById('chat-form') as HTMLFormElement
     this.chatTextarea = document.getElementById('chat-input') as HTMLTextAreaElement
     this.chatLabel = document.getElementById('chat-label') as HTMLLabelElement
@@ -56,10 +59,9 @@ export class ChatTextareaComponent implements CodayEventHandler {
 
     this.chatTextarea.addEventListener('keydown', async (e) => {
       const useEnterToSend = getPreference<boolean>('useEnterToSend', false)
-      const os = this.detectOS()
       
       if ((useEnterToSend && e.key === 'Enter' && !e.shiftKey) || 
-          (!useEnterToSend && ((os === 'mac' && e.metaKey) || (os === 'non-mac' && e.ctrlKey)) && e.key === 'Enter')) {
+          (!useEnterToSend && ((this.os === 'mac' && e.metaKey) || (this.os === 'non-mac' && e.ctrlKey)) && e.key === 'Enter')) {
         e.preventDefault()
         await this.submit()
       }

--- a/apps/web/client/chat-textarea/chat-textarea.component.ts
+++ b/apps/web/client/chat-textarea/chat-textarea.component.ts
@@ -44,7 +44,7 @@ export class ChatTextareaComponent implements CodayEventHandler {
     this.chatForm = document.getElementById('chat-form') as HTMLFormElement
     this.chatTextarea = document.getElementById('chat-input') as HTMLTextAreaElement
     this.chatLabel = document.getElementById('chat-label') as HTMLLabelElement
-    this.submitButton = document.querySelector('.submit') as HTMLButtonElement
+    this.submitButton = document.getElementById('send-button') as HTMLButtonElement
 
     this.chatForm.onsubmit = async (event) => {
       event.preventDefault()

--- a/apps/web/client/chat-textarea/chat-textarea.component.ts
+++ b/apps/web/client/chat-textarea/chat-textarea.component.ts
@@ -60,10 +60,18 @@ export class ChatTextareaComponent implements CodayEventHandler {
     this.chatTextarea.addEventListener('keydown', async (e) => {
       const useEnterToSend = getPreference<boolean>('useEnterToSend', false)
       
-      if ((useEnterToSend && e.key === 'Enter' && !e.shiftKey) || 
-          (!useEnterToSend && ((this.os === 'mac' && e.metaKey) || (this.os === 'non-mac' && e.ctrlKey)) && e.key === 'Enter')) {
-        e.preventDefault()
-        await this.submit()
+      if (useEnterToSend) {
+        // When Enter to Send is enabled, only handle plain Enter (without Shift)
+        if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+          e.preventDefault()
+          await this.submit()
+        }
+      } else {
+        // When Enter to Send is disabled, use OS-specific shortcuts
+        if (e.key === 'Enter' && ((this.os === 'mac' && e.metaKey) || (this.os === 'non-mac' && e.ctrlKey))) {
+          e.preventDefault()
+          await this.submit()
+        }
       }
     })
     

--- a/apps/web/client/chat-textarea/chat-textarea.component.ts
+++ b/apps/web/client/chat-textarea/chat-textarea.component.ts
@@ -6,7 +6,6 @@ export class ChatTextareaComponent implements CodayEventHandler {
   private chatForm: HTMLFormElement
   private chatTextarea: HTMLTextAreaElement
   private chatLabel: HTMLLabelElement
-  private expandToggle: HTMLButtonElement
   private submitButton: HTMLButtonElement
   private inviteEvent: InviteEvent | undefined
   private readonly os: 'mac' | 'non-mac'
@@ -23,9 +22,9 @@ export class ChatTextareaComponent implements CodayEventHandler {
    */
   private updateSendButtonLabel(): void {
     const useEnterToSend = getPreference<boolean>('useEnterToSend', false)
-    
+
     if (!this.submitButton) return
-    
+
     if (useEnterToSend) {
       this.submitButton.innerHTML = 'SEND <br/><br/>enter'
     } else {
@@ -40,7 +39,7 @@ export class ChatTextareaComponent implements CodayEventHandler {
   constructor(private postEvent: (event: CodayEvent) => Promise<Response>) {
     // Detect OS once during initialization
     this.os = this.detectOS()
-    
+
     this.chatForm = document.getElementById('chat-form') as HTMLFormElement
     this.chatTextarea = document.getElementById('chat-input') as HTMLTextAreaElement
     this.chatLabel = document.getElementById('chat-label') as HTMLLabelElement
@@ -51,15 +50,9 @@ export class ChatTextareaComponent implements CodayEventHandler {
       await this.submit()
     }
 
-    this.expandToggle = document.getElementById('expand-toggle') as HTMLButtonElement
-    this.expandToggle.onclick = () => {
-      const expanded = this.chatTextarea.classList.toggle('expanded-textarea')
-      this.expandToggle.textContent = expanded ? 'Collapse' : 'Expand'
-    }
-
     this.chatTextarea.addEventListener('keydown', async (e) => {
       const useEnterToSend = getPreference<boolean>('useEnterToSend', false)
-      
+
       if (useEnterToSend) {
         // When Enter to Send is enabled, only handle plain Enter (without Shift)
         if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
@@ -74,10 +67,10 @@ export class ChatTextareaComponent implements CodayEventHandler {
         }
       }
     })
-    
+
     // Update the button label initially
     this.updateSendButtonLabel()
-    
+
     // Listen for preference changes
     window.addEventListener('storage', (event) => {
       if (event.key === 'coday-preferences') {
@@ -92,7 +85,7 @@ export class ChatTextareaComponent implements CodayEventHandler {
       // Parse markdown for the chat label
       const parsed = marked.parse(this.inviteEvent.invite)
       if (parsed instanceof Promise) {
-        parsed.then(html => this.chatLabel.innerHTML = html)
+        parsed.then((html) => (this.chatLabel.innerHTML = html))
       } else {
         this.chatLabel.innerHTML = parsed
       }

--- a/apps/web/client/chat-textarea/chat-textarea.component.ts
+++ b/apps/web/client/chat-textarea/chat-textarea.component.ts
@@ -1,5 +1,6 @@
 import { CodayEvent, InviteEvent } from '@coday/shared/coday-events'
 import { CodayEventHandler } from '../utils/coday-event-handler'
+import { getPreference } from '../utils/preferences'
 
 export class ChatTextareaComponent implements CodayEventHandler {
   private chatForm: HTMLFormElement
@@ -25,9 +26,12 @@ export class ChatTextareaComponent implements CodayEventHandler {
     }
 
     this.chatTextarea.addEventListener('keydown', async (e) => {
-      if (e.metaKey && e.key === 'Enter') {
-        e.preventDefault()
-        await this.submit()
+      const useEnterToSend = getPreference('useEnterToSend', false);
+      
+      if ((useEnterToSend && e.key === 'Enter' && !e.shiftKey) || 
+          (!useEnterToSend && e.metaKey && e.key === 'Enter')) {
+        e.preventDefault();
+        await this.submit();
       }
     })
   }

--- a/apps/web/client/chat-textarea/chat-textarea.css
+++ b/apps/web/client/chat-textarea/chat-textarea.css
@@ -1,41 +1,40 @@
 #chat-form {
-  padding: 1em;
-  background-color: #44475a;
-  border-top: 1px solid #6272a4;
+    padding: 1em;
+    background-color: var(--color-bg-secondary);
+    border-top: 1px solid var(--color-border);
 }
 
 textarea {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 1em;
-  flex-grow: 1;
-  padding: 0.5em;
-  border-radius: 0.5em;
-  margin-right: 0.7em;
-  border: 1px solid #6272a4;
-  box-sizing: border-box;
-  resize: vertical;
-  background-color: #282a36;
-  color: #f8f8f2;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1em;
+    flex-grow: 1;
+    padding: 0.5em;
+    border-radius: 0.5em;
+    margin-right: 0.7em;
+    border: 1px solid var(--color-border);
+    box-sizing: border-box;
+    resize: vertical;
+    background-color: var(--color-bg);
+    color: var(--color-text);
 }
 
 textarea:focus {
-  outline: none;
-  border-color: #bd93f9;
-  box-shadow: 0 0 0 2px rgba(189, 147, 249, 0.2);
+    outline: none;
+    border-color: var(--color-primary);
 }
 
 textarea::placeholder {
-  color: #6272a4;
+    color: var(--color-text-secondary);
 }
 
 .expanded-textarea {
-  height: 70vh;
+    height: 50vh;
 }
 
 .submit {
-  flex-grow: 1;
+    flex-grow: 1;
 }
 
 #expand-toggle {
-  margin-bottom: 0.5em;
+    margin-bottom: 0.5em;
 }

--- a/apps/web/client/chat-textarea/chat-textarea.css
+++ b/apps/web/client/chat-textarea/chat-textarea.css
@@ -13,9 +13,12 @@ textarea {
     margin-right: 0.7em;
     border: 1px solid var(--color-border);
     box-sizing: border-box;
-    resize: vertical;
+    resize: none;
     background-color: var(--color-bg);
     color: var(--color-text);
+    min-height: 3em;
+    field-sizing: content;
+    max-height: 40vh;
 }
 
 textarea:focus {
@@ -27,14 +30,6 @@ textarea::placeholder {
     color: var(--color-text-secondary);
 }
 
-.expanded-textarea {
-    height: 50vh;
-}
-
 .submit {
     flex-grow: 1;
-}
-
-#expand-toggle {
-    margin-bottom: 0.5em;
 }

--- a/apps/web/client/choice-select/choice-select.css
+++ b/apps/web/client/choice-select/choice-select.css
@@ -21,7 +21,7 @@
 
 #choice-select option {
     background-color: var(--color-bg);
-    color: var(--color-text-secondary);
+    color: var(--color-text);
     padding: 0.5em;
 }
 
@@ -31,7 +31,7 @@
 }
 
 #choices-label {
-    color: var(--color-text-secondary);
+    color: var(--color-text);
     margin-bottom: 0.5em;
     font-family: 'JetBrains Mono', monospace;
 }

--- a/apps/web/client/choice-select/choice-select.css
+++ b/apps/web/client/choice-select/choice-select.css
@@ -1,42 +1,41 @@
 #choice-form {
-  padding: 1em;
-  background-color: #44475a;
-  border-top: 1px solid #6272a4;
+    padding: 1em;
+    background-color: var(--color-bg-secondary);
+    border-top: 1px solid var(--color-border);
 }
 
 #choice-select {
-  flex-grow: 1;
-  padding: 1em;
-  background-color: #282a36;
-  color: #f8f8f2;
-  border: 1px solid #6272a4;
-  border-radius: 0.5em;
-  font-family: 'JetBrains Mono', monospace;
+    flex-grow: 1;
+    padding: 1em;
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5em;
+    font-family: 'JetBrains Mono', monospace;
 }
 
 #choice-select:focus {
-  outline: none;
-  border-color: #bd93f9;
-  box-shadow: 0 0 0 2px rgba(189, 147, 249, 0.2);
+    outline: none;
+    border-color: var(--color-primary);
 }
 
 #choice-select option {
-  background-color: #282a36;
-  color: #f8f8f2;
-  padding: 0.5em;
+    background-color: var(--color-bg);
+    color: var(--color-text-secondary);
+    padding: 0.5em;
 }
 
 #choice-select option:hover,
 #choice-select option:focus {
-  background-color: #44475a;
+    background-color: var(--color-primary);
 }
 
 #choices-label {
-  color: #f8f8f2;
-  margin-bottom: 0.5em;
-  font-family: 'JetBrains Mono', monospace;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.5em;
+    font-family: 'JetBrains Mono', monospace;
 }
 
 #send-choice-button {
-  margin-left: 0.7em;
+    margin-left: 0.7em;
 }

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -15,9 +15,9 @@
   </head>
   <body>
     <!-- Transparent header positioned over the content -->
-    <div style="padding: 8px; text-align: right; position: fixed; top: 0; left: 0; right: 0; z-index: 1000; background-color: transparent;">
-      <button id="options-button" style="background-color: rgba(68, 71, 90, 0.7); padding: 5px 10px; border-radius: 4px; border: 1px solid rgba(98, 114, 164, 0.5); color: #f8f8f2;">⚙️ Options</button>
-      <div id="options-panel" style="display: none; padding: 10px; background-color: #282a36; position: absolute; right: 8px; top: 40px; border: 1px solid #6272a4; z-index: 1000; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);">
+    <div class="overlay-header">
+      <button id="options-button">⚙️ Options</button>
+      <div id="options-panel">
         <div>
           <label>
             <input type="checkbox" id="enter-to-send-toggle">

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -14,10 +14,10 @@
     <link rel="stylesheet" href="choice-select/choice-select.css" />
   </head>
   <body>
-    <!-- Super simple options button -->
-    <div style="padding: 8px; background-color: #44475a; text-align: right;">
-      <button id="options-button">⚙️ Options</button>
-      <div id="options-panel" style="display: none; padding: 10px; background-color: #282a36; position: absolute; right: 8px; border: 1px solid #6272a4; z-index: 100;">
+    <!-- Transparent header positioned over the content -->
+    <div style="padding: 8px; text-align: right; position: fixed; top: 0; left: 0; right: 0; z-index: 1000; background-color: transparent;">
+      <button id="options-button" style="background-color: rgba(68, 71, 90, 0.7); padding: 5px 10px; border-radius: 4px; border: 1px solid rgba(98, 114, 164, 0.5); color: #f8f8f2;">⚙️ Options</button>
+      <div id="options-panel" style="display: none; padding: 10px; background-color: #282a36; position: absolute; right: 8px; top: 40px; border: 1px solid #6272a4; z-index: 1000; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);">
         <div>
           <label>
             <input type="checkbox" id="enter-to-send-toggle">

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -14,6 +14,18 @@
     <link rel="stylesheet" href="choice-select/choice-select.css" />
   </head>
   <body>
+    <!-- Super simple options button -->
+    <div style="padding: 8px; background-color: #44475a; text-align: right;">
+      <button id="options-button">⚙️ Options</button>
+      <div id="options-panel" style="display: none; padding: 10px; background-color: #282a36; position: absolute; right: 8px; border: 1px solid #6272a4; z-index: 100;">
+        <div>
+          <label>
+            <input type="checkbox" id="enter-to-send-toggle">
+            Use Enter to send (Shift+Enter for new line)
+          </label>
+        </div>
+      </div>
+    </div>
     <main>
       <div id="chat-history">
         <div id="thinking-dots" class="text right">

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <base href="/"/>
+    <link rel="stylesheet" href="styles/colors.css"/>
     <link rel="stylesheet" href="styles/global.css"/>
     <link rel="stylesheet" href="styles/main.css"/>
     <link rel="stylesheet" href="styles/button.css"/>

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -50,7 +50,7 @@
 </div>
 <main>
     <div id="chat-history">
-        <div id="thinking-dots" class="text right">
+        <div id="thinking-dots" class="text left">
             <div class="dots"><span>.</span><span>.</span><span>.</span></div>
             <button type="button" class="stop-button" title="Stop current execution">⏹️</button>
         </div>

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -65,7 +65,6 @@
                 <textarea id="chat-input" placeholder="Type your message here..."></textarea>
             </div>
             <div class="column">
-                <button type="button" id="expand-toggle">Expand</button>
                 <button type="submit" id="send-button" class="submit">SEND <br/><br/>cmd/win + <br/>enter</button>
             </div>
         </div>

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -66,7 +66,7 @@
             </div>
             <div class="column">
                 <button type="button" id="expand-toggle">Expand</button>
-                <button type="submit" class="submit">SEND <br/><br/>cmd/win + <br/>enter</button>
+                <button type="submit" id="send-button" class="submit">SEND <br/><br/>cmd/win + <br/>enter</button>
             </div>
         </div>
     </form>

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -19,11 +19,32 @@
 <div class="overlay-header">
     <button id="options-button">⚙️</button>
     <div id="options-panel">
-        <div>
+        <div style="margin-bottom: 10px;">
             <label>
                 <input type="checkbox" id="enter-to-send-toggle">
                 Use Enter to send (Shift+Enter for new line)
             </label>
+        </div>
+        <div>
+            <p style="margin: 5px 0;">Theme:</p>
+            <div>
+                <label>
+                    <input type="radio" name="theme" value="light" id="theme-light">
+                    Light
+                </label>
+            </div>
+            <div>
+                <label>
+                    <input type="radio" name="theme" value="dark" id="theme-dark">
+                    Dark
+                </label>
+            </div>
+            <div>
+                <label>
+                    <input type="radio" name="theme" value="system" id="theme-system">
+                    System
+                </label>
+            </div>
         </div>
     </div>
 </div>

--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -1,66 +1,66 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <base href="/" />
-    <link rel="stylesheet" href="styles/global.css" />
-    <link rel="stylesheet" href="styles/main.css" />
-    <link rel="stylesheet" href="styles/button.css" />
-    <link rel="stylesheet" href="styles/header.css" />
-    <link rel="stylesheet" href="styles/utilities.css" />
-    <link rel="stylesheet" href="chat-history/chat-history.css" />
-    <link rel="stylesheet" href="chat-textarea/chat-textarea.css" />
-    <link rel="stylesheet" href="choice-select/choice-select.css" />
-  </head>
-  <body>
-    <!-- Transparent header positioned over the content -->
-    <div class="overlay-header">
-      <button id="options-button">⚙️ Options</button>
-      <div id="options-panel">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <base href="/"/>
+    <link rel="stylesheet" href="styles/global.css"/>
+    <link rel="stylesheet" href="styles/main.css"/>
+    <link rel="stylesheet" href="styles/button.css"/>
+    <link rel="stylesheet" href="styles/header.css"/>
+    <link rel="stylesheet" href="styles/utilities.css"/>
+    <link rel="stylesheet" href="chat-history/chat-history.css"/>
+    <link rel="stylesheet" href="chat-textarea/chat-textarea.css"/>
+    <link rel="stylesheet" href="choice-select/choice-select.css"/>
+</head>
+<body>
+<!-- Transparent header positioned over the content -->
+<div class="overlay-header">
+    <button id="options-button">⚙️</button>
+    <div id="options-panel">
         <div>
-          <label>
-            <input type="checkbox" id="enter-to-send-toggle">
-            Use Enter to send (Shift+Enter for new line)
-          </label>
+            <label>
+                <input type="checkbox" id="enter-to-send-toggle">
+                Use Enter to send (Shift+Enter for new line)
+            </label>
         </div>
-      </div>
     </div>
-    <main>
-      <div id="chat-history">
+</div>
+<main>
+    <div id="chat-history">
         <div id="thinking-dots" class="text right">
-          <div class="dots"><span>.</span><span>.</span><span>.</span></div>
-          <button type="button" class="stop-button" title="Stop current execution">⏹️</button>
+            <div class="dots"><span>.</span><span>.</span><span>.</span></div>
+            <button type="button" class="stop-button" title="Stop current execution">⏹️</button>
         </div>
-      </div>
-    </main>
-    <footer>
-      <!-- Chat Textarea Block -->
-      <form id="chat-form" style="display: none">
+    </div>
+</main>
+<footer>
+    <!-- Chat Textarea Block -->
+    <form id="chat-form" style="display: none">
         <div class="row">
-          <div class="column" style="flex-grow: 1">
-            <label id="chat-label" for="chat-input"></label>
-            <textarea id="chat-input" placeholder="Type your message here..."></textarea>
-          </div>
-          <div class="column">
-            <button type="button" id="expand-toggle">Expand</button>
-            <button type="submit" class="submit">SEND <br /><br />cmd/win + <br />enter</button>
-          </div>
+            <div class="column" style="flex-grow: 1">
+                <label id="chat-label" for="chat-input"></label>
+                <textarea id="chat-input" placeholder="Type your message here..."></textarea>
+            </div>
+            <div class="column">
+                <button type="button" id="expand-toggle">Expand</button>
+                <button type="submit" class="submit">SEND <br/><br/>cmd/win + <br/>enter</button>
+            </div>
         </div>
-      </form>
+    </form>
 
-      <!-- Choice Select Block -->
-      <form id="choice-form" style="display: none">
+    <!-- Choice Select Block -->
+    <form id="choice-form" style="display: none">
         <div class="row">
-          <div class="column" style="flex-grow: 1">
-            <label id="choices-label" for="choice-select"></label>
-            <select id="choice-select"></select>
-          </div>
-          <button type="submit" id="send-choice-button">Choose</button>
+            <div class="column" style="flex-grow: 1">
+                <label id="choices-label" for="choice-select"></label>
+                <select id="choice-select"></select>
+            </div>
+            <button type="submit" id="send-choice-button">Choose</button>
         </div>
-      </form>
-    </footer>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script type="module" src="app.js"></script>
-  </body>
+    </form>
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script type="module" src="app.js"></script>
+</body>
 </html>

--- a/apps/web/client/styles/button.css
+++ b/apps/web/client/styles/button.css
@@ -1,8 +1,8 @@
 button {
   padding: 0.5em;
   margin: 0.2em;
-  background-color: #bd93f9;
-  color: #f8f8f2;
+  background-color: var(--color-button-bg);
+  color: var(--color-foreground);
   border: none;
   border-radius: 0.5em;
   cursor: pointer;
@@ -12,5 +12,5 @@ button {
 }
 
 button:hover {
-  background-color: #ff79c6;
+  background-color: var(--color-button-hover);
 }

--- a/apps/web/client/styles/button.css
+++ b/apps/web/client/styles/button.css
@@ -1,16 +1,16 @@
 button {
-  padding: 0.5em;
-  margin: 0.2em;
-  background-color: var(--color-button-bg);
-  color: var(--color-foreground);
-  border: none;
-  border-radius: 0.5em;
-  cursor: pointer;
-  flex-shrink: 0;
-  box-sizing: border-box;
-  font-family: 'JetBrains Mono', monospace;
+    padding: 0.5em;
+    margin: 0.2em;
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+    border-color: var(--color-border);
+    border-radius: 0.5em;
+    cursor: pointer;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    font-family: 'JetBrains Mono', monospace;
 }
 
 button:hover {
-  background-color: var(--color-button-hover);
+    background-color: var(--color-primary-hover);
 }

--- a/apps/web/client/styles/colors.css
+++ b/apps/web/client/styles/colors.css
@@ -1,62 +1,63 @@
 /**
- * Coday Color Variables (Dracula Theme)
+ * Coday Color Variables
  * 
- * This file defines all color variables used throughout the application.
- * Use these variables instead of hardcoded color values to maintain consistency
- * and make theme changes easier.
+ * A simplified theme system with essential color variables.
+ * Default theme is light, with dark theme available via data-theme="dark".
  */
 
 :root {
+  /* Light Theme (Default) */
+  
   /* Base Colors */
-  --color-background: #282a36;         /* Main background color */
-  --color-current-line: #44475a;       /* Secondary background, highlights, panels */
-  --color-foreground: #f8f8f2;         /* Primary text color */
-  --color-comment: #6272a4;            /* Secondary text, comments, less important elements */
+  --color-bg: #f8f8f2;
+  --color-bg-secondary: #f1f1eb;
+  --color-text: #282a36;
+  --color-text-secondary: #6272a4;
   
-  /* Accent Colors */
-  --color-cyan: #8be9fd;               /* Cyan accent */
-  --color-green: #50fa7b;              /* Green accent */
-  --color-orange: #ffb86c;             /* Orange accent */
-  --color-pink: #ff79c6;               /* Pink accent */
-  --color-purple: #bd93f9;             /* Purple accent */
-  --color-red: #ff5555;                /* Red accent */
-  --color-yellow: #f1fa8c;             /* Yellow accent */
+  /* Interactive Elements */
+  --color-primary: #bd93f9;
+  --color-primary-hover: #ff79c6;
+  --color-border: #d8d8d8;
+  --color-input-bg: #ffffff;
   
-  /* Semantic Colors (based on usage) */
-  --color-primary: var(--color-purple);       /* Primary interactive elements */
-  --color-primary-hover: var(--color-pink);   /* Hover state for primary elements */
-  --color-secondary: var(--color-comment);    /* Secondary elements */
-  --color-border: var(--color-comment);       /* Borders */
-  --color-shadow: rgba(0, 0, 0, 0.3);         /* Shadows */
-  --color-error: var(--color-red);            /* Error states */
-  --color-success: var(--color-green);        /* Success states */
-  --color-warning: var(--color-orange);       /* Warning states */
-  --color-info: var(--color-cyan);            /* Info states */
+  /* Status Colors */
+  --color-success: #50fa7b;
+  --color-error: #ff5555;
+  --color-warning: #ffb86c;
+  --color-info: #8be9fd;
   
-  /* Component-specific Colors */
-  --color-header-bg: var(--color-current-line);
-  --color-footer-bg: var(--color-current-line);
-  --color-input-bg: var(--color-background);
-  --color-button-bg: var(--color-purple);
-  --color-button-hover: var(--color-pink);
-  --color-message-user-bg: var(--color-comment);
-  --color-message-ai-bg: var(--color-current-line);
-  --color-code-bg: var(--color-current-line);
-  --color-highlight: var(--color-purple);
+  /* Application-Specific */
+  --color-message-user: #e4e4f1;
+  --color-message-ai: #f1f1eb;
+  --color-code-bg: #f1f1eb;
   
-  /* Transparent Variants */
-  --color-current-line-70: rgba(68, 71, 90, 0.7);
-  --color-current-line-90: rgba(68, 71, 90, 0.9);
-  --color-purple-20: rgba(189, 147, 249, 0.2);
-  --color-comment-50: rgba(98, 114, 164, 0.5);
+  /* Utility Colors */
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-overlay: rgba(0, 0, 0, 0.3);
 }
 
-/* Dark theme is default, but we can add a light theme or other themes */
-[data-theme="light"] {
-  /* Light theme variables would go here */
-  /* Example:
-  --color-background: #f8f8f2;
-  --color-foreground: #282a36;
-  etc.
-  */
+/* Dark Theme */
+[data-theme="dark"] {
+  /* Base Colors */
+  --color-bg: #282a36;
+  --color-bg-secondary: #44475a;
+  --color-text: #f8f8f2;
+  --color-text-secondary: #6272a4;
+  
+  /* Interactive Elements */
+  --color-primary: #bd93f9;
+  --color-primary-hover: #ff79c6;
+  --color-border: #6272a4;
+  --color-input-bg: #282a36;
+  
+  /* Status Colors remain the same for consistency */
+  
+  /* Application-Specific */
+  --color-message-user: #6272a4;
+  --color-message-ai: #44475a;
+  --color-code-bg: #44475a;
+  
+  /* Utility Colors */
+  --color-shadow: rgba(0, 0, 0, 0.3);
+  --color-overlay: rgba(0, 0, 0, 0.7);
 }

--- a/apps/web/client/styles/colors.css
+++ b/apps/web/client/styles/colors.css
@@ -28,9 +28,9 @@
     --color-info: #8be9fd;
 
     /* Application-Specific */
-    --color-message-user: #e0e0e0;
-    --color-message-ai: #f6f2e8;
-    --color-code-bg: #f1f1eb;
+    --color-message-user: #e2dee2;
+    --color-message-ai: #e8ecf6;
+    --color-code-bg: #1e1f29;
 
     /* Utility Colors */
     --color-shadow: rgba(0, 0, 0, 0.1);
@@ -40,14 +40,14 @@
 /* Dark Theme */
 [data-theme="dark"] {
     /* Base Colors */
-    --color-bg: #282a36;
+    --color-bg: #333339;
     --color-bg-secondary: #44475a;
     --color-text: #f8f8f2;
     --color-text-secondary: #6272a4;
     --color-text-inverse: #ffffff;
 
     /* Interactive Elements */
-    --color-primary: #bd93f9;
+    --color-primary: #e4d1ff;
     --color-primary-hover: #ff79c6;
     --color-border: #6272a4;
     --color-input-bg: #282a36;
@@ -55,9 +55,9 @@
     /* Status Colors remain the same for consistency */
 
     /* Application-Specific */
-    --color-message-user: #6272a4;
-    --color-message-ai: #44475a;
-    --color-code-bg: #44475a;
+    --color-message-user: #6a5b7e;
+    --color-message-ai: #677088;
+    --color-code-bg: #1e1f29;
 
     /* Utility Colors */
     --color-shadow: rgba(0, 0, 0, 0.3);

--- a/apps/web/client/styles/colors.css
+++ b/apps/web/client/styles/colors.css
@@ -6,58 +6,58 @@
  */
 
 :root {
-  /* Light Theme (Default) */
-  
-  /* Base Colors */
-  --color-bg: #f8f8f2;
-  --color-bg-secondary: #f1f1eb;
-  --color-text: #282a36;
-  --color-text-secondary: #6272a4;
-  
-  /* Interactive Elements */
-  --color-primary: #bd93f9;
-  --color-primary-hover: #ff79c6;
-  --color-border: #d8d8d8;
-  --color-input-bg: #ffffff;
-  
-  /* Status Colors */
-  --color-success: #50fa7b;
-  --color-error: #ff5555;
-  --color-warning: #ffb86c;
-  --color-info: #8be9fd;
-  
-  /* Application-Specific */
-  --color-message-user: #e4e4f1;
-  --color-message-ai: #f1f1eb;
-  --color-code-bg: #f1f1eb;
-  
-  /* Utility Colors */
-  --color-shadow: rgba(0, 0, 0, 0.1);
-  --color-overlay: rgba(0, 0, 0, 0.3);
+    /* Light Theme (Default) */
+
+    /* Base Colors */
+    --color-bg: #f8f8f2;
+    --color-bg-secondary: #f1f1eb;
+    --color-text: #282a36;
+    --color-text-secondary: #6272a4;
+
+    /* Interactive Elements */
+    --color-primary: #7064fb;
+    --color-primary-hover: #ff79c6;
+    --color-border: #aeaeae;
+    --color-input-bg: #ffffff;
+
+    /* Status Colors */
+    --color-success: #50fa7b;
+    --color-error: #ff5555;
+    --color-warning: #ffb86c;
+    --color-info: #8be9fd;
+
+    /* Application-Specific */
+    --color-message-user: #e0e0e0;
+    --color-message-ai: #f6f2e8;
+    --color-code-bg: #f1f1eb;
+
+    /* Utility Colors */
+    --color-shadow: rgba(0, 0, 0, 0.1);
+    --color-overlay: rgba(0, 0, 0, 0.3);
 }
 
 /* Dark Theme */
 [data-theme="dark"] {
-  /* Base Colors */
-  --color-bg: #282a36;
-  --color-bg-secondary: #44475a;
-  --color-text: #f8f8f2;
-  --color-text-secondary: #6272a4;
-  
-  /* Interactive Elements */
-  --color-primary: #bd93f9;
-  --color-primary-hover: #ff79c6;
-  --color-border: #6272a4;
-  --color-input-bg: #282a36;
-  
-  /* Status Colors remain the same for consistency */
-  
-  /* Application-Specific */
-  --color-message-user: #6272a4;
-  --color-message-ai: #44475a;
-  --color-code-bg: #44475a;
-  
-  /* Utility Colors */
-  --color-shadow: rgba(0, 0, 0, 0.3);
-  --color-overlay: rgba(0, 0, 0, 0.7);
+    /* Base Colors */
+    --color-bg: #282a36;
+    --color-bg-secondary: #44475a;
+    --color-text: #f8f8f2;
+    --color-text-secondary: #6272a4;
+
+    /* Interactive Elements */
+    --color-primary: #bd93f9;
+    --color-primary-hover: #ff79c6;
+    --color-border: #6272a4;
+    --color-input-bg: #282a36;
+
+    /* Status Colors remain the same for consistency */
+
+    /* Application-Specific */
+    --color-message-user: #6272a4;
+    --color-message-ai: #44475a;
+    --color-code-bg: #44475a;
+
+    /* Utility Colors */
+    --color-shadow: rgba(0, 0, 0, 0.3);
+    --color-overlay: rgba(0, 0, 0, 0.7);
 }

--- a/apps/web/client/styles/colors.css
+++ b/apps/web/client/styles/colors.css
@@ -13,6 +13,7 @@
     --color-bg-secondary: #f1f1eb;
     --color-text: #282a36;
     --color-text-secondary: #6272a4;
+    --color-text-inverse: #ffffff;
 
     /* Interactive Elements */
     --color-primary: #7064fb;
@@ -43,6 +44,7 @@
     --color-bg-secondary: #44475a;
     --color-text: #f8f8f2;
     --color-text-secondary: #6272a4;
+    --color-text-inverse: #ffffff;
 
     /* Interactive Elements */
     --color-primary: #bd93f9;

--- a/apps/web/client/styles/colors.css
+++ b/apps/web/client/styles/colors.css
@@ -1,0 +1,62 @@
+/**
+ * Coday Color Variables (Dracula Theme)
+ * 
+ * This file defines all color variables used throughout the application.
+ * Use these variables instead of hardcoded color values to maintain consistency
+ * and make theme changes easier.
+ */
+
+:root {
+  /* Base Colors */
+  --color-background: #282a36;         /* Main background color */
+  --color-current-line: #44475a;       /* Secondary background, highlights, panels */
+  --color-foreground: #f8f8f2;         /* Primary text color */
+  --color-comment: #6272a4;            /* Secondary text, comments, less important elements */
+  
+  /* Accent Colors */
+  --color-cyan: #8be9fd;               /* Cyan accent */
+  --color-green: #50fa7b;              /* Green accent */
+  --color-orange: #ffb86c;             /* Orange accent */
+  --color-pink: #ff79c6;               /* Pink accent */
+  --color-purple: #bd93f9;             /* Purple accent */
+  --color-red: #ff5555;                /* Red accent */
+  --color-yellow: #f1fa8c;             /* Yellow accent */
+  
+  /* Semantic Colors (based on usage) */
+  --color-primary: var(--color-purple);       /* Primary interactive elements */
+  --color-primary-hover: var(--color-pink);   /* Hover state for primary elements */
+  --color-secondary: var(--color-comment);    /* Secondary elements */
+  --color-border: var(--color-comment);       /* Borders */
+  --color-shadow: rgba(0, 0, 0, 0.3);         /* Shadows */
+  --color-error: var(--color-red);            /* Error states */
+  --color-success: var(--color-green);        /* Success states */
+  --color-warning: var(--color-orange);       /* Warning states */
+  --color-info: var(--color-cyan);            /* Info states */
+  
+  /* Component-specific Colors */
+  --color-header-bg: var(--color-current-line);
+  --color-footer-bg: var(--color-current-line);
+  --color-input-bg: var(--color-background);
+  --color-button-bg: var(--color-purple);
+  --color-button-hover: var(--color-pink);
+  --color-message-user-bg: var(--color-comment);
+  --color-message-ai-bg: var(--color-current-line);
+  --color-code-bg: var(--color-current-line);
+  --color-highlight: var(--color-purple);
+  
+  /* Transparent Variants */
+  --color-current-line-70: rgba(68, 71, 90, 0.7);
+  --color-current-line-90: rgba(68, 71, 90, 0.9);
+  --color-purple-20: rgba(189, 147, 249, 0.2);
+  --color-comment-50: rgba(98, 114, 164, 0.5);
+}
+
+/* Dark theme is default, but we can add a light theme or other themes */
+[data-theme="light"] {
+  /* Light theme variables would go here */
+  /* Example:
+  --color-background: #f8f8f2;
+  --color-foreground: #282a36;
+  etc.
+  */
+}

--- a/apps/web/client/styles/global.css
+++ b/apps/web/client/styles/global.css
@@ -5,12 +5,13 @@ body {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background-color: #282a36;
-  color: #f8f8f2;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 h1 {
   font-size: 1.5em;
   margin: 0;
-  color: #ff79c6;
+  color: var(--color-primary-hover);
 }

--- a/apps/web/client/styles/global.css
+++ b/apps/web/client/styles/global.css
@@ -15,3 +15,9 @@ h1 {
   margin: 0;
   color: var(--color-primary-hover);
 }
+
+/* Text selection styling */
+::selection {
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse, #ffffff);
+}

--- a/apps/web/client/styles/header.css
+++ b/apps/web/client/styles/header.css
@@ -8,7 +8,7 @@ header {
 /* Transparent overlay header */
 .overlay-header {
     padding: 4px 8px; /* Reduced padding to minimize height */
-    text-align: right;
+    text-align: end;
     position: fixed;
     top: 0;
     left: 0;
@@ -34,6 +34,7 @@ header {
 /* Options panel */
 #options-panel {
     display: none;
+    text-align: start;
     padding: 10px;
     background-color: var(--color-bg-secondary);
     position: absolute;
@@ -43,4 +44,6 @@ header {
     z-index: 1000;
     box-shadow: 0 4px 8px var(--color-shadow);
     border-radius: 4px;
+    flex-direction: column;
+    align-items: flex-start;
 }

--- a/apps/web/client/styles/header.css
+++ b/apps/web/client/styles/header.css
@@ -1,46 +1,46 @@
 header {
-  background-color: var(--color-bg-secondary);
-  padding: 0.5em;
-  border-bottom: 1px solid var(--color-border);
-  transition: background-color 0.3s ease, border-color 0.3s ease;
+    background-color: var(--color-bg-secondary);
+    padding: 0.5em;
+    border-bottom: 1px solid var(--color-border);
+    transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 /* Transparent overlay header */
 .overlay-header {
-  padding: 4px 8px; /* Reduced padding to minimize height */
-  text-align: right;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-  background-color: transparent;
+    padding: 4px 8px; /* Reduced padding to minimize height */
+    text-align: right;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background-color: transparent;
 }
 
 /* Options button */
 #options-button {
-  background-color: var(--color-current-line-70);
-  padding: 5px 10px;
-  border-radius: 4px;
-  border: 1px solid var(--color-comment-50);
-  color: var(--color-foreground);
-  cursor: pointer;
+    background-color: var(--color-bg);
+    padding: 5px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
+    color: var(--color-bg);
+    cursor: pointer;
 }
 
 #options-button:hover {
-  background-color: var(--color-current-line-90);
+    background-color: var(--color-bg-secondary);
 }
 
 /* Options panel */
 #options-panel {
-  display: none;
-  padding: 10px;
-  background-color: var(--color-background);
-  position: absolute;
-  right: 8px;
-  top: 35px; /* Adjusted to match reduced header height */
-  border: 1px solid var(--color-border);
-  z-index: 1000;
-  box-shadow: 0 4px 8px var(--color-shadow);
-  border-radius: 4px;
+    display: none;
+    padding: 10px;
+    background-color: var(--color-bg-secondary);
+    position: absolute;
+    right: 8px;
+    top: 35px; /* Adjusted to match reduced header height */
+    border: 1px solid var(--color-border);
+    z-index: 1000;
+    box-shadow: 0 4px 8px var(--color-shadow);
+    border-radius: 4px;
 }

--- a/apps/web/client/styles/header.css
+++ b/apps/web/client/styles/header.css
@@ -3,3 +3,43 @@ header {
   padding: 0.5em;
   border-bottom: 1px solid #6272a4;
 }
+
+/* Transparent overlay header */
+.overlay-header {
+  padding: 4px 8px; /* Reduced padding to minimize height */
+  text-align: right;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background-color: transparent;
+}
+
+/* Options button */
+#options-button {
+  background-color: rgba(68, 71, 90, 0.7);
+  padding: 5px 10px;
+  border-radius: 4px;
+  border: 1px solid rgba(98, 114, 164, 0.5);
+  color: #f8f8f2;
+  cursor: pointer;
+}
+
+#options-button:hover {
+  background-color: rgba(68, 71, 90, 0.9);
+}
+
+/* Options panel */
+#options-panel {
+  display: none;
+  padding: 10px;
+  background-color: #282a36;
+  position: absolute;
+  right: 8px;
+  top: 35px; /* Adjusted to match reduced header height */
+  border: 1px solid #6272a4;
+  z-index: 1000;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+}

--- a/apps/web/client/styles/header.css
+++ b/apps/web/client/styles/header.css
@@ -1,7 +1,7 @@
 header {
-  background-color: #44475a;
+  background-color: var(--color-header-bg);
   padding: 0.5em;
-  border-bottom: 1px solid #6272a4;
+  border-bottom: 1px solid var(--color-border);
 }
 
 /* Transparent overlay header */
@@ -18,28 +18,28 @@ header {
 
 /* Options button */
 #options-button {
-  background-color: rgba(68, 71, 90, 0.7);
+  background-color: var(--color-current-line-70);
   padding: 5px 10px;
   border-radius: 4px;
-  border: 1px solid rgba(98, 114, 164, 0.5);
-  color: #f8f8f2;
+  border: 1px solid var(--color-comment-50);
+  color: var(--color-foreground);
   cursor: pointer;
 }
 
 #options-button:hover {
-  background-color: rgba(68, 71, 90, 0.9);
+  background-color: var(--color-current-line-90);
 }
 
 /* Options panel */
 #options-panel {
   display: none;
   padding: 10px;
-  background-color: #282a36;
+  background-color: var(--color-background);
   position: absolute;
   right: 8px;
   top: 35px; /* Adjusted to match reduced header height */
-  border: 1px solid #6272a4;
+  border: 1px solid var(--color-border);
   z-index: 1000;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 8px var(--color-shadow);
   border-radius: 4px;
 }

--- a/apps/web/client/styles/header.css
+++ b/apps/web/client/styles/header.css
@@ -1,7 +1,8 @@
 header {
-  background-color: var(--color-header-bg);
+  background-color: var(--color-bg-secondary);
   padding: 0.5em;
   border-bottom: 1px solid var(--color-border);
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 /* Transparent overlay header */

--- a/apps/web/client/styles/main.css
+++ b/apps/web/client/styles/main.css
@@ -5,7 +5,7 @@ main {
   justify-content: flex-start;
   overflow-y: auto;
   margin: 0;
-  padding: 30px 0 0 0; /* Added top padding to prevent content from being hidden under the header */
+  padding: 20px 0 0 0; /* Reduced top padding to match smaller header */
   background-color: #282a36;
   color: #f8f8f2;
 }

--- a/apps/web/client/styles/main.css
+++ b/apps/web/client/styles/main.css
@@ -6,6 +6,7 @@ main {
   overflow-y: auto;
   margin: 0;
   padding: 20px 0 0 0; /* Reduced top padding to match smaller header */
-  background-color: #282a36;
-  color: #f8f8f2;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }

--- a/apps/web/client/styles/main.css
+++ b/apps/web/client/styles/main.css
@@ -5,7 +5,7 @@ main {
   justify-content: flex-start;
   overflow-y: auto;
   margin: 0;
-  padding: 0;
+  padding: 30px 0 0 0; /* Added top padding to prevent content from being hidden under the header */
   background-color: #282a36;
   color: #f8f8f2;
 }

--- a/apps/web/client/utils/preferences.ts
+++ b/apps/web/client/utils/preferences.ts
@@ -1,0 +1,35 @@
+/**
+ * Simple utility for managing user preferences in the browser
+ */
+
+const STORAGE_KEY = 'coday-preferences';
+
+/**
+ * Get a user preference
+ */
+export function getPreference<T>(key: string, defaultValue?: T): T | undefined {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return defaultValue;
+    
+    const preferences = JSON.parse(stored);
+    return preferences[key] !== undefined ? preferences[key] : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+/**
+ * Set a user preference
+ */
+export function setPreference<T>(key: string, value: T): void {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    const preferences = stored ? JSON.parse(stored) : {};
+    
+    preferences[key] = value;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+  } catch (error) {
+    console.error('Failed to set preference:', error);
+  }
+}


### PR DESCRIPTION
add local-storage-scoped UI options for:
- sending behavior: on enter or mod + enter
- theme selection: light/dark/system
- no more `Expand` button needed for the textarea

Also user messages on right, AI on left, that is an heresy but also a popular demand...