### PR TITLE
Prompt history

### DIFF
--- a/apps/terminal/terminal-interactor.ts
+++ b/apps/terminal/terminal-interactor.ts
@@ -1,4 +1,4 @@
-import { input, select } from '@inquirer/prompts'
+import { select } from '@inquirer/prompts'
 import chalk from 'chalk'
 import { Interactor } from '@coday/model/interactor'
 import {
@@ -10,9 +10,13 @@ import {
   ThinkingEvent,
   WarnEvent,
 } from '@coday/shared/coday-events'
+import * as readline from 'node:readline'
 
 export class TerminalInteractor extends Interactor {
   private interactionInProgress = false
+  private promptHistory: string[] = []
+  private historyIndex = 0
+  private rl: readline.Interface | null = null
 
   constructor() {
     super()
@@ -27,8 +31,8 @@ export class TerminalInteractor extends Interactor {
         this.displayFormattedText(event.answer, event.invite)
       }
       if (event instanceof ErrorEvent) {
-        const errorMessage = event.error instanceof Error ? event.error.message : String(event.error);
-        console.error(chalk.red(`\n❌ Error: ${errorMessage}\n`));
+        const errorMessage = event.error instanceof Error ? event.error.message : String(event.error)
+        console.error(chalk.red(`\n❌ Error: ${errorMessage}\n`))
       }
       if (event instanceof InviteEvent) {
         this.handleInviteEvent(event)
@@ -47,16 +51,113 @@ export class TerminalInteractor extends Interactor {
     console.log(formattedText)
   }
 
+  /**
+   * Setup readline interface with history support
+   */
+  private setupReadlineInterface(prompt: string, defaultValue?: string): Promise<string> {
+    return new Promise((resolve) => {
+      // Create a new readline interface
+      this.rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      })
+      
+      // Set up history navigation
+      this.historyIndex = this.promptHistory.length
+      let tempInput = defaultValue || ''
+      
+      // Enable raw mode for better handling of keypress events
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(true)
+      }
+      
+      // Make sure we can process keypresses
+      readline.emitKeypressEvents(process.stdin)
+      
+      // Process key events for history navigation
+      const keypressHandler = (str: string, key: any) => {
+        if (!key) return
+        
+        // Handle Up Arrow - History navigation
+        if (key.name === 'up' && this.promptHistory.length > 0) {
+          // Save current input on first navigation
+          if (this.historyIndex === this.promptHistory.length) {
+            tempInput = this.rl?.line || ''
+          }
+          
+          // Go back in history if possible
+          if (this.historyIndex > 0) {
+            this.historyIndex--
+            
+            // Clear current line and write historical item
+            this.rl?.write('', { ctrl: true, name: 'u' })
+            this.rl?.write(this.promptHistory[this.historyIndex])
+          }
+        }
+        
+        // Handle Down Arrow - History navigation
+        if (key.name === 'down' && this.historyIndex < this.promptHistory.length) {
+          this.historyIndex++
+          
+          // Clear current line
+          this.rl?.write('', { ctrl: true, name: 'u' })
+          
+          if (this.historyIndex === this.promptHistory.length) {
+            // At the end, restore the original input
+            this.rl?.write(tempInput)
+          } else {
+            // Show the next history item
+            this.rl?.write(this.promptHistory[this.historyIndex])
+          }
+        }
+      }
+      
+      // Register our keypress handler
+      process.stdin.on('keypress', keypressHandler)
+      
+      // Show the prompt and wait for input
+      this.rl.question(prompt, (answer) => {
+        // Save to history if not empty and not a duplicate
+        if (answer && answer.trim() !== '') {
+          if (this.promptHistory.length === 0 || this.promptHistory[this.promptHistory.length - 1] !== answer) {
+            this.promptHistory.push(answer)
+          }
+        }
+        
+        // Clean up resources
+        if (process.stdin.isTTY) {
+          process.stdin.setRawMode(false)
+        }
+        process.stdin.removeListener('keypress', keypressHandler)
+        
+        if (this.rl) {
+          this.rl.close()
+          this.rl = null
+        }
+        
+        // Return the user's answer
+        resolve(answer)
+      })
+      
+      // Set initial value if provided
+      if (defaultValue) {
+        this.rl.write(defaultValue)
+      }
+    })
+  }
+
   handleInviteEvent(event: InviteEvent): void {
     this.interactionInProgress = true
-    input({
-      message: `\n${chalk.black.bgWhite(event.invite)} : `,
-      default: event.defaultValue
-    })
+
+    const prompt = `\n${chalk.black.bgWhite(event.invite)} : `
+
+    this.setupReadlineInterface(prompt, event.defaultValue)
       .then((answer: string) => {
         this.sendEvent(event.buildAnswer(answer))
       })
-      .finally(() => (this.interactionInProgress = false))
+      .finally(() => {
+        this.interactionInProgress = false
+      })
   }
 
   handleChoiceEvent(event: ChoiceEvent): void {
@@ -73,5 +174,19 @@ export class TerminalInteractor extends Interactor {
         this.sendEvent(event.buildAnswer(answer))
       })
       .finally(() => (this.interactionInProgress = false))
+  }
+
+  /**
+   * Clean up resources when the terminal is closing
+   */
+  cleanup(): void {
+    if (this.rl) {
+      this.rl.close()
+    }
+
+    // Reset terminal settings
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false)
+    }
   }
 }

--- a/apps/terminal/terminal-interactor.ts
+++ b/apps/terminal/terminal-interactor.ts
@@ -11,23 +11,35 @@ import {
   WarnEvent,
 } from '@coday/shared/coday-events'
 import * as readline from 'node:readline'
+import { Key } from 'node:readline' // Import Key type for clarity
+
+// Interface augmentation to acknowledge internal properties/methods used
+// This helps centralize the 'any' casts or '@ts-ignore' reasons.
+interface ReadlineInterfaceWithInternals extends readline.Interface {
+  line: string // Allow assignment for our custom handling
+  cursor: number // Allow assignment for our custom handling
+  _refreshLine(): void // Acknowledge internal method
+  // Add other internal properties/methods if needed
+}
 
 export class TerminalInteractor extends Interactor {
   private interactionInProgress = false
   private promptHistory: string[] = []
-  private rl: readline.Interface | null = null
+  private rl: ReadlineInterfaceWithInternals | null = null // Use augmented type
+  private keypressListener: ((str: string, key: Key) => void) | null = null
 
   constructor() {
     super()
     this.events.subscribe((event) => {
+      // ... (rest of constructor remains the same) ...
       if (event instanceof TextEvent) {
         this.displayFormattedText(event.text, event.speaker)
       }
       if (event instanceof WarnEvent) {
-        console.warn(`${event.warning}\n`)
+        console.warn(`${chalk.yellow('⚠️ Warning:')} ${event.warning}\n`)
       }
       if (event instanceof AnswerEvent && !this.interactionInProgress) {
-        this.displayFormattedText(event.answer, event.invite)
+        this.displayFormattedText(event.answer, event.invite || 'Response')
       }
       if (event instanceof ErrorEvent) {
         const errorMessage = event.error instanceof Error ? event.error.message : String(event.error)
@@ -40,267 +52,242 @@ export class TerminalInteractor extends Interactor {
         this.handleChoiceEvent(event)
       }
       if (event instanceof ThinkingEvent) {
-        console.log('.')
+        process.stdout.write(chalk.blue('.'))
       }
     })
+
+    process.on('SIGINT', () => this.cleanupAndExit())
+    process.on('SIGTERM', () => this.cleanupAndExit())
   }
 
   private displayFormattedText(text: string, speaker?: string): void {
-    const formattedText = speaker ? `\n${chalk.black.bgWhite(speaker)} : ${text}\n` : text
+    // ... (remains the same) ...
+    readline.clearLine(process.stdout, 0)
+    readline.cursorTo(process.stdout, 0)
+
+    const formattedText = speaker ? `\n${chalk.black.bgWhite(` ${speaker} `)} ${text}\n` : `${text}\n`
     console.log(formattedText)
   }
 
   /**
-   * Setup readline interface with history support
+   * Setup readline interface with history and multi-line support using keypress listener.
+   * NOTE: This function directly manipulates internal 'line' and 'cursor' properties
+   * and uses the internal '_refreshLine' method to achieve custom multi-line editing
+   * and history behavior, bypassing TypeScript's read-only checks as the public API
+   * lacks sufficient control for this purpose.
    */
   private setupReadlineInterface(prompt: string, defaultValue?: string): Promise<string> {
-    return new Promise((resolve) => {
-      // Create a new readline interface
-      this.rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      })
-      
-      // Initialize history - not used by our class variable anymore
-      // History is managed in the ttyWrite method
-      
-      // Enable raw mode for better handling of keypress events
+    this.cleanupReadline()
+
+    return new Promise((resolve, reject) => {
+      try {
+        // Cast to our augmented interface acknowledging internal access
+        this.rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+          prompt: prompt,
+          //history: wn cannot use the native history behavior while maintaining multiline
+          //         prompts (otherwise we can't navigate within these lines)
+          crlfDelay: Infinity,
+          tabSize: 4,
+        }) as ReadlineInterfaceWithInternals
+      } catch (error) {
+        return reject(error)
+      }
+
+      let currentHistoryIndex = -1
+      let originalInput = ''
+      let isSubmitting = false
+
+      const cleanupAndResolve = (answer: string) => {
+        // ... (rest of function remains the same) ...
+        if (isSubmitting) return
+        isSubmitting = true
+
+        this.cleanupReadline()
+
+        const trimmedAnswer = answer.trim()
+        if (trimmedAnswer) {
+          if (this.promptHistory.length === 0 || this.promptHistory[this.promptHistory.length - 1] !== trimmedAnswer) {
+            this.promptHistory.push(trimmedAnswer)
+            // Optional: Limit history size
+            // if (this.promptHistory.length > 50) {
+            //   this.promptHistory.shift();
+            // }
+          }
+        }
+        resolve(answer)
+      }
+
+      this.keypressListener = (str: string, key: Key) => {
+        if (!this.rl || isSubmitting) return
+
+        const currentLine = this.rl.line // Read is fine
+        const cursor = this.rl.cursor // Read is fine
+
+        // --- Alt+Enter (Meta+Return) for Newline ---
+        if (key && key.meta && key.name === 'return') {
+          const beforeCursor = currentLine.slice(0, cursor)
+          const afterCursor = currentLine.slice(cursor)
+          // NOTE: Direct assignment bypasses TS read-only restriction
+          this.rl.line = `${beforeCursor}\n${afterCursor}`
+          this.rl.cursor = cursor + 1
+          this.rl._refreshLine() // Use internal refresh
+          return // Prevent default handling
+        }
+
+        // --- Standard Enter ---
+        if (key && key.name === 'return' && !key.meta && !key.ctrl && !key.shift) {
+          // Let the 'line' event handle submission
+          return
+        }
+
+        // --- Up Arrow ---
+        if (key && key.name === 'up' && !key.meta && !key.ctrl && !key.shift) {
+          const { lineIndex, positionInLine } = this.getCursorPositionInfo(currentLine, cursor)
+
+          if (lineIndex > 0) {
+            // --- Multi-line Navigation Up ---
+            // const prevLine = lines[lineIndex - 1]; // Unused variable removed
+            const newCursor = this.calculateNewCursorPos(currentLine, lineIndex - 1, positionInLine)
+            // NOTE: Direct assignment bypasses TS read-only restriction
+            this.rl.cursor = newCursor
+            this.rl._refreshLine()
+            return // Prevent history navigation
+          } else {
+            // --- History Navigation Up ---
+            if (this.promptHistory.length === 0) return
+
+            if (currentHistoryIndex === -1) {
+              originalInput = currentLine
+              currentHistoryIndex = this.promptHistory.length - 1
+            } else if (currentHistoryIndex > 0) {
+              currentHistoryIndex--
+            } else {
+              return
+            }
+
+            // NOTE: Direct assignment bypasses TS read-only restriction
+            const historyLine = this.promptHistory[currentHistoryIndex]
+            this.rl.line = historyLine
+            this.rl.cursor = historyLine.length
+            this.rl._refreshLine()
+            return
+          }
+        }
+
+        // --- Down Arrow ---
+        if (key && key.name === 'down' && !key.meta && !key.ctrl && !key.shift) {
+          const lines = currentLine.split('\n')
+          const { lineIndex, positionInLine } = this.getCursorPositionInfo(currentLine, cursor)
+
+          if (lineIndex < lines.length - 1) {
+            // --- Multi-line Navigation Down ---
+            // const nextLine = lines[lineIndex + 1]; // Unused variable removed
+            const newCursor = this.calculateNewCursorPos(currentLine, lineIndex + 1, positionInLine)
+            // NOTE: Direct assignment bypasses TS read-only restriction
+            this.rl.cursor = newCursor
+            this.rl._refreshLine()
+            return // Prevent history navigation / moving past input
+          } else {
+            // --- History Navigation Down ---
+            if (currentHistoryIndex === -1) {
+              return
+            }
+
+            let historyLine: string
+            if (currentHistoryIndex < this.promptHistory.length - 1) {
+              currentHistoryIndex++
+              historyLine = this.promptHistory[currentHistoryIndex]
+            } else {
+              currentHistoryIndex = -1
+              historyLine = originalInput
+            }
+            // NOTE: Direct assignment bypasses TS read-only restriction
+            this.rl.line = historyLine
+            this.rl.cursor = historyLine.length
+            this.rl._refreshLine()
+            return
+          }
+        }
+
+        // Reset history navigation if user types anything other than arrows/enter
+        if (currentHistoryIndex !== -1 && key && !['up', 'down', 'return'].includes(key.name || '')) {
+          currentHistoryIndex = -1
+          originalInput = ''
+        }
+      }
+
+      // Enable raw mode and attach listener
       if (process.stdin.isTTY) {
         process.stdin.setRawMode(true)
       }
-      
-      // Make sure we can process keypresses
       readline.emitKeypressEvents(process.stdin)
-      
-      let isSubmitting = false;
+      process.stdin.on('keypress', this.keypressListener)
 
-      // Override the default readline _ttyWrite method to capture Enter and Alt+Enter
-      if (this.rl) {
-        const originalTtyWrite = (this.rl as any)._ttyWrite;
-        
-        if (originalTtyWrite) {
-          (this.rl as any)._ttyWrite = function(s: string, key: any) {
-            // Intercept Alt+Enter to insert a newline instead of submitting
-            if (key && key.name === 'return' && key.meta) {
-              // Manually insert newline at current cursor position
-              this.line = this.line.slice(0, this.cursor) + 
-                            '\n' + 
-                            this.line.slice(this.cursor);
-              this.cursor++;
-              
-              // Refresh the line display
-              this._refreshLine();
-              return;
-            }
-            
-            // Prevent submission when cursor is not at the end of multiline input
-            if (key && key.name === 'return' && !key.meta && !key.ctrl && !key.shift) {
-              // Check if we're in the middle of a multiline input
-              const lineAfterCursor = this.line.slice(this.cursor);
-              if (lineAfterCursor.includes('\n')) {
-                // If there are more lines after cursor, move cursor to next line instead of submitting
-                const nextNewlinePos = lineAfterCursor.indexOf('\n');
-                this.cursor += nextNewlinePos + 1;
-                this._refreshLine();
-                return;
-              }
-            }
-            
-            // Otherwise call the original method for all other keys
-            return originalTtyWrite.call(this, s, key);
-          };
-        }
-      }
-      
-      // We need to override readline's default handling of up/down arrows
-      // to provide the right behavior for multiline inputs
-      if (this.rl && (this.rl as any)._ttyWrite) {
-        const originalTtyWrite = (this.rl as any)._ttyWrite;
-        
-        // Override to handle both Alt+Enter and arrow navigation
-        (this.rl as any)._ttyWrite = function(s: string, key: any) {
-          // Handle Alt+Enter for multiline input
-          if (key && key.name === 'return' && key.meta) {
-            // Manually insert newline at current cursor position
-            this.line = this.line.slice(0, this.cursor) + 
-                          '\n' + 
-                          this.line.slice(this.cursor);
-            this.cursor++;
-            
-            // Refresh the line display
-            this._refreshLine();
-            return;
-          }
-          
-          // Get current line and cursor position
-          const line = this.line || '';
-          const cursor = this.cursor || 0;
-          
-          // Helper functions to check cursor position and navigate vertically
-          const countLines = (text: string) => (text.match(/\n/g) || []).length + 1;
-          
-          // Calculate current line number and total lines
-          const textBeforeCursor = line.substring(0, cursor);
-          const currentLineNum = countLines(textBeforeCursor);
-          const totalLines = countLines(line);
-          
-          // Find position of cursor in current line
-          const lastNewlineBeforeCursor = textBeforeCursor.lastIndexOf('\n');
-          const positionInCurrentLine = lastNewlineBeforeCursor === -1 ? 
-                                       cursor : 
-                                       cursor - lastNewlineBeforeCursor - 1;
-          
-          // Handle Up Arrow key
-          if (key && key.name === 'up') {
-            if (currentLineNum === 1) {
-              // If on first line, use history if available
-              if (tempHistoryIndex < promptHistory.length) {
-                // First time going into history mode
-                if (tempHistoryIndex === 0) {
-                  tempInput = line;
-                }
-                tempHistoryIndex++;
-                
-                // Get historical item from end of array
-                const historyIndex = promptHistory.length - tempHistoryIndex;
-                this.line = promptHistory[historyIndex];
-                this.cursor = this.line.length;
-                this._refreshLine();
-              }
-            } else {
-              // Find the previous newline to calculate the position
-              let searchPos = lastNewlineBeforeCursor - 1;
-              let prevNewlinePos = textBeforeCursor.lastIndexOf('\n', searchPos);
-              
-              // If previous line exists, calculate its length
-              if (prevNewlinePos === -1) {
-                // First line
-                const prevLineLength = lastNewlineBeforeCursor;
-                let newCursor = Math.min(positionInCurrentLine, prevLineLength);
-                this.cursor = newCursor;
-              } else {
-                // Other lines
-                const prevLineLength = lastNewlineBeforeCursor - prevNewlinePos - 1;
-                let newCursor = prevNewlinePos + 1 + Math.min(positionInCurrentLine, prevLineLength);
-                this.cursor = newCursor;
-              }
-              
-              this._refreshLine();
-            }
-            return;
-          }
-          
-          // Handle Down Arrow key
-          if (key && key.name === 'down') {
-            if (currentLineNum === totalLines) {
-              // If on last line, navigate history forward
-              if (tempHistoryIndex > 0) {
-                tempHistoryIndex--;
-                
-                if (tempHistoryIndex === 0) {
-                  this.line = tempInput;
-                  this.cursor = this.line.length;
-                } else {
-                  // Get history item 
-                  const historyIndex = promptHistory.length - tempHistoryIndex;
-                  this.line = promptHistory[historyIndex];
-                  this.cursor = this.line.length;
-                }
-                this._refreshLine();
-              }
-            } else {
-              // Find the next newline position
-              const nextNewlinePos = line.indexOf('\n', cursor);
-              
-              if (nextNewlinePos !== -1) {
-                // Get position after the newline
-                const posAfterNewline = nextNewlinePos + 1;
-                
-                // Find end of next line 
-                const endOfNextLine = line.indexOf('\n', posAfterNewline);
-                
-                // Calculate length of next line
-                const nextLineLength = endOfNextLine === -1 ? 
-                                      line.length - posAfterNewline : 
-                                      endOfNextLine - posAfterNewline;
-                
-                // Set cursor position in the next line
-                const newCursor = posAfterNewline + Math.min(positionInCurrentLine, nextLineLength);
-                this.cursor = newCursor;
-                this._refreshLine();
-              }
-            }
-            return;
-          }
-          
-          // For all other keys, pass through to original handler
-          return originalTtyWrite.call(this, s, key);
-        };
-        
-        // Setup access to history
-        const promptHistory = this.promptHistory;
-        let tempHistoryIndex = 0;
-        let tempInput = '';
-      }
-      
-      // Our separate keypress handler for other functions
-      const keypressHandler = (str: string, key: any) => {
-        if (!key) return
-        
-        // Skip if we're in the process of submitting
-        if (isSubmitting) return
-      }
-      
-      // Register our keypress handler
-      process.stdin.on('keypress', keypressHandler)
-      
-      // Show the prompt and wait for input
-      this.rl.question(prompt, (answer) => {
-        // Mark as submitting to prevent further keypress handling
-        isSubmitting = true;
-        
-        // Save to history if not empty and not a duplicate
-        if (answer && answer.trim() !== '') {
-          if (this.promptHistory.length === 0 || this.promptHistory[this.promptHistory.length - 1] !== answer) {
-            this.promptHistory.push(answer)
-          }
-        }
-        
-        // Clean up resources
-        if (process.stdin.isTTY) {
-          process.stdin.setRawMode(false)
-        }
-        process.stdin.removeListener('keypress', keypressHandler)
-        
-        if (this.rl) {
-          // Restore original _ttyWrite method if we modified it
-          if ((this.rl as any)._ttyWrite && typeof (this.rl as any)._ttyWrite !== 'function') {
-            (this.rl as any)._ttyWrite = undefined;
-          }
-          
-          this.rl.close()
-          this.rl = null
-        }
-        
-        // Return the user's answer
-        resolve(answer)
+      // Handle the 'line' event for submission
+      this.rl.on('line', (input) => {
+        cleanupAndResolve(input)
       })
-      
-      // Set initial value if provided
+
+      // Handle 'close' event for cleanup if interface closes unexpectedly
+      this.rl.on('close', () => {
+        this.cleanupReadline()
+      })
+
+      // Display initial prompt and default value
+      this.rl.prompt()
       if (defaultValue) {
         this.rl.write(defaultValue)
       }
     })
   }
 
+  // Helper to get cursor line index and position within that line
+  private getCursorPositionInfo(text: string, cursor: number): { lineIndex: number; positionInLine: number } {
+    // ... (remains the same) ...
+    const textBeforeCursor = text.slice(0, cursor)
+    const linesBeforeCursor = textBeforeCursor.split('\n')
+    const lineIndex = linesBeforeCursor.length - 1
+    const positionInLine = linesBeforeCursor[lineIndex].length
+    return { lineIndex, positionInLine }
+  }
+
+  // Helper to calculate new cursor position when moving vertically
+  private calculateNewCursorPos(text: string, targetLineIndex: number, desiredPositionInLine: number): number {
+    // ... (remains the same) ...
+    const lines = text.split('\n')
+    const targetLine = lines[targetLineIndex]
+    const targetPosition = Math.min(desiredPositionInLine, targetLine.length)
+
+    let newCursor = 0
+    for (let i = 0; i < targetLineIndex; i++) {
+      newCursor += lines[i].length + 1 // +1 for the newline character
+    }
+    newCursor += targetPosition
+    return newCursor
+  }
+
   handleInviteEvent(event: InviteEvent): void {
+    // ... (remains the same) ...
+    if (this.interactionInProgress) {
+      console.warn(chalk.yellow('Warning: Interaction already in progress. Ignoring new invite.'))
+      return
+    }
     this.interactionInProgress = true
 
-    const prompt = `\n${chalk.black.bgWhite(event.invite)} : `
+    readline.clearLine(process.stdout, 0)
+    readline.cursorTo(process.stdout, 0)
+
+    const prompt = `\n${chalk.black.bgWhite(` ${event.invite} `)} : `
 
     this.setupReadlineInterface(prompt, event.defaultValue)
       .then((answer: string) => {
         this.sendEvent(event.buildAnswer(answer))
+      })
+      .catch((error) => {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        console.error(chalk.red(`\n❌ Input Error: ${errorMessage}\n`))
       })
       .finally(() => {
         this.interactionInProgress = false
@@ -308,10 +295,19 @@ export class TerminalInteractor extends Interactor {
   }
 
   handleChoiceEvent(event: ChoiceEvent): void {
-    const { options, invite, optionalQuestion } = event
+    // ... (remains the same) ...
+    if (this.interactionInProgress) {
+      console.warn(chalk.yellow('Warning: Interaction already in progress. Ignoring new choice.'))
+      return
+    }
     this.interactionInProgress = true
+
+    readline.clearLine(process.stdout, 0)
+    readline.cursorTo(process.stdout, 0)
+
+    const { options, invite, optionalQuestion } = event
     select({
-      message: optionalQuestion ? `${optionalQuestion} :\n${invite}` : invite,
+      message: optionalQuestion ? `${optionalQuestion}\n${chalk.bold(invite)}:` : `${chalk.bold(invite)}:`,
       choices: options.map((option) => ({
         name: option,
         value: option,
@@ -320,20 +316,56 @@ export class TerminalInteractor extends Interactor {
       .then((answer: string) => {
         this.sendEvent(event.buildAnswer(answer))
       })
+      .catch((error) => {
+        if (error?.message?.includes('User force closed')) {
+          console.log(chalk.yellow('\nChoice cancelled.'))
+        } else {
+          const errorMessage = error instanceof Error ? error.message : String(error)
+          console.error(chalk.red(`\n❌ Choice Error: ${errorMessage}\n`))
+        }
+      })
       .finally(() => (this.interactionInProgress = false))
   }
 
   /**
-   * Clean up resources when the terminal is closing
+   * Cleans up the readline interface and associated resources.
    */
-  cleanup(): void {
-    if (this.rl) {
-      this.rl.close()
+  private cleanupReadline(): void {
+    // ... (remains the same) ...
+    if (this.keypressListener && process.stdin.listenerCount('keypress') > 0) {
+      process.stdin.removeListener('keypress', this.keypressListener)
+      this.keypressListener = null
     }
 
-    // Reset terminal settings
-    if (process.stdin.isTTY) {
-      process.stdin.setRawMode(false)
+    if (this.rl) {
+      this.rl.close()
+      this.rl = null
     }
+
+    if (process.stdin.isTTY && process.stdin.listenerCount('keypress') === 0) {
+      try {
+        process.stdin.setRawMode(false)
+      } catch (e) {
+        // Ignore
+      }
+    }
+  }
+
+  /**
+   * General cleanup for the interactor.
+   */
+  cleanup(): void {
+    // ... (remains the same) ...
+    console.log('\nCleaning up terminal interactor...')
+    this.cleanupReadline()
+  }
+
+  /**
+   * Cleanup and exit the process.
+   */
+  cleanupAndExit(): void {
+    // ... (remains the same) ...
+    this.cleanup()
+    process.exit(0)
   }
 }

--- a/apps/terminal/terminal-interactor.ts
+++ b/apps/terminal/terminal-interactor.ts
@@ -56,6 +56,8 @@ export class TerminalInteractor extends Interactor {
       }
     })
 
+    this.displayText('Enter: new line, Alt+Enter: submit')
+
     process.on('SIGINT', () => this.cleanupAndExit())
     process.on('SIGTERM', () => this.cleanupAndExit())
   }
@@ -132,7 +134,8 @@ export class TerminalInteractor extends Interactor {
         const currentLine = this.rl.line // Read is fine
         const cursor = this.rl.cursor // Read is fine
 
-        if (key && key.meta && key.name === 'return') {
+        // Submit on ANY modifier + Enter (Alt, Ctrl, or Shift), for broad terminal compatibility
+        if (key && key.name === 'return' && (key.meta || key.ctrl || key.shift)) {
           // Let the 'line' event handle submission
           this.rl.emit('line', currentLine)
           return

--- a/apps/terminal/terminal.ts
+++ b/apps/terminal/terminal.ts
@@ -21,6 +21,20 @@ const integration = new IntegrationService(project, user)
 const memory = new MemoryService(project, user)
 const mcp = new McpConfigService(user, project, interactor)
 
+// Setup cleanup for terminal interactor when process exits
+if (interactor instanceof TerminalInteractor) {
+  // Clean up readline interface on exit
+  process.on('exit', () => {
+    interactor.cleanup()
+  })
+  
+  // Let Node.js handle Ctrl+C normally
+  process.on('SIGINT', () => {
+    console.log('\nExiting...')
+    process.exit(0)
+  })
+}
+
 new Coday(interactor, options, {
   user,
   project,

--- a/apps/web/client/chat-textarea/chat-textarea.component.ts
+++ b/apps/web/client/chat-textarea/chat-textarea.component.ts
@@ -9,6 +9,11 @@ export class ChatTextareaComponent implements CodayEventHandler {
   private submitButton: HTMLButtonElement
   private inviteEvent: InviteEvent | undefined
   private readonly os: 'mac' | 'non-mac'
+  
+  // Command history for arrow key navigation
+  private promptHistory: string[] = []
+  private historyIndex: number = -1
+  private tempInput: string = ''
 
   /**
    * Detect operating system for keyboard shortcuts
@@ -53,6 +58,7 @@ export class ChatTextareaComponent implements CodayEventHandler {
     this.chatTextarea.addEventListener('keydown', async (e) => {
       const useEnterToSend = getPreference<boolean>('useEnterToSend', false)
 
+      // Handle Enter key for submission
       if (useEnterToSend) {
         // When Enter to Send is enabled, only handle plain Enter (without Shift)
         if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
@@ -64,6 +70,21 @@ export class ChatTextareaComponent implements CodayEventHandler {
         if (e.key === 'Enter' && ((this.os === 'mac' && e.metaKey) || (this.os === 'non-mac' && e.ctrlKey))) {
           e.preventDefault()
           await this.submit()
+        }
+      }
+      
+      // Handle Up/Down arrow keys for history navigation
+      if (e.key === 'ArrowUp') {
+        // Only navigate history if cursor is at the first line
+        if (this.isCursorAtFirstLine()) {
+          e.preventDefault()
+          this.navigateHistory('up')
+        }
+      } else if (e.key === 'ArrowDown') {
+        // Only navigate history if cursor is at the last line
+        if (this.isCursorAtLastLine()) {
+          e.preventDefault()
+          this.navigateHistory('down')
         }
       }
     })
@@ -97,16 +118,96 @@ export class ChatTextareaComponent implements CodayEventHandler {
     }
   }
 
+  /**
+   * Check if cursor is at the first line of text
+   */
+  private isCursorAtFirstLine(): boolean {
+    const text = this.chatTextarea.value;
+    const cursorPos = this.chatTextarea.selectionStart;
+    
+    // If cursor is at position 0, it's definitely at the first line
+    if (cursorPos === 0) return true;
+    
+    // Otherwise, check if there are any newline characters before the cursor
+    const textBeforeCursor = text.substring(0, cursorPos);
+    return textBeforeCursor.indexOf('\n') === -1;
+  }
+  
+  /**
+   * Check if cursor is at the last line of text
+   */
+  private isCursorAtLastLine(): boolean {
+    const text = this.chatTextarea.value;
+    const cursorPos = this.chatTextarea.selectionStart;
+    
+    // If cursor is at the end, it's definitely at the last line
+    if (cursorPos === text.length) return true;
+    
+    // Otherwise, check if there are any newline characters after the cursor
+    const textAfterCursor = text.substring(cursorPos);
+    return textAfterCursor.indexOf('\n') === -1;
+  }
+
+  /**
+   * Navigate through command history using up/down arrows
+   */
+  private navigateHistory(direction: 'up' | 'down'): void {
+    // If history is empty, do nothing
+    if (this.promptHistory.length === 0) return;
+    
+    // On first up arrow press, save current input
+    if (direction === 'up' && this.historyIndex === -1) {
+      this.tempInput = this.chatTextarea.value;
+    }
+    
+    if (direction === 'up' && this.historyIndex < this.promptHistory.length - 1) {
+      // Move up in history
+      this.historyIndex++;
+      this.chatTextarea.value = this.promptHistory[this.promptHistory.length - 1 - this.historyIndex];
+      this.moveCursorToEnd();
+    } else if (direction === 'down' && this.historyIndex > -1) {
+      // Move down in history
+      this.historyIndex--;
+      
+      if (this.historyIndex === -1) {
+        // We've reached the end of history, restore the temporary input
+        this.chatTextarea.value = this.tempInput;
+      } else {
+        this.chatTextarea.value = this.promptHistory[this.promptHistory.length - 1 - this.historyIndex];
+      }
+      this.moveCursorToEnd();
+    }
+  }
+  
+  /**
+   * Move cursor to the end of the textarea
+   */
+  private moveCursorToEnd(): void {
+    const length = this.chatTextarea.value.length;
+    this.chatTextarea.setSelectionRange(length, length);
+  }
+
   private async submit(): Promise<void> {
-    const answer = this.inviteEvent?.buildAnswer(this.chatTextarea.value)
+    const inputValue = this.chatTextarea.value.trim();
+    const answer = this.inviteEvent?.buildAnswer(inputValue)
+    
     if (!answer) {
       return
     }
+    
     try {
       this.chatForm.style.display = 'none'
       const response = await this.postEvent(answer)
+      
       if (response.ok) {
-        this.chatTextarea.value = ''
+        // Add to history if not empty and not a duplicate of the last entry
+        if (inputValue && (this.promptHistory.length === 0 || this.promptHistory[this.promptHistory.length - 1] !== inputValue)) {
+          this.promptHistory.push(inputValue);
+        }
+        
+        this.chatTextarea.value = '';
+        this.historyIndex = -1; // Reset history index
+        this.tempInput = '';
       } else {
         this.chatForm.style.display = 'block'
         this.chatTextarea.focus()

--- a/libs/handler/openai.client.ts
+++ b/libs/handler/openai.client.ts
@@ -13,7 +13,7 @@ import { RunSubmitToolOutputsParams } from 'openai/resources/beta/threads/runs/r
 const OpenaiModels = {
   [ModelSize.BIG]: {
     name: 'gpt-4.1-2025-04-14',
-    contextWindow: 128000,
+    contextWindow: 1000000,
     price: {
       inputMTokens: 2,
       cacheRead: 0.5,

--- a/libs/handler/openai.client.ts
+++ b/libs/handler/openai.client.ts
@@ -12,12 +12,12 @@ import { RunSubmitToolOutputsParams } from 'openai/resources/beta/threads/runs/r
 
 const OpenaiModels = {
   [ModelSize.BIG]: {
-    name: 'gpt-4o',
+    name: 'gpt-4.1-2025-04-14',
     contextWindow: 128000,
     price: {
-      inputMTokens: 2.5,
-      cacheRead: 1.25,
-      outputMTokens: 10,
+      inputMTokens: 2,
+      cacheRead: 0.5,
+      outputMTokens: 8,
     },
   },
   [ModelSize.SMALL]: {
@@ -177,7 +177,7 @@ export class OpenaiClient extends AiClient {
         await this.processThread(client, agent, thread, subscriber)
       }
     } catch (error: any) {
-      this.handleError(error, subscriber, this.providerName);
+      this.handleError(error, subscriber, this.providerName)
     }
   }
 
@@ -214,7 +214,7 @@ export class OpenaiClient extends AiClient {
         baseURL: this.apiUrl,
       })
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       this.interactor.warn(`Failed to initialize ${this.providerName} client: ${errorMessage}`)
       console.error(`${this.providerName} client initialization error:`, error)
       return
@@ -273,21 +273,21 @@ export class OpenaiClient extends AiClient {
     messagesToUpload: ThreadMessage[]
   ): Promise<void> {
     try {
-    // WARNING: this part sucks, OpenAI API not allowing multiple messages at once T_T, so forced iterations
-    this.interactor.displayText(`${messagesToUpload.length} messages to upload to assistant thread...`)
-    for (const messagesToUploadElement of messagesToUpload) {
-      if (!this.shouldProceed(thread)) {
-        throw new Error('Assistant thread update interrupted')
+      // WARNING: this part sucks, OpenAI API not allowing multiple messages at once T_T, so forced iterations
+      this.interactor.displayText(`${messagesToUpload.length} messages to upload to assistant thread...`)
+      for (const messagesToUploadElement of messagesToUpload) {
+        if (!this.shouldProceed(thread)) {
+          throw new Error('Assistant thread update interrupted')
+        }
+        const assistantMessage = this.toAssistantMessage(messagesToUploadElement)
+        await client.beta.threads.messages.create(thread.data.openai.assistantThreadData.threadId, assistantMessage)
+        // update the marker in case of interruption to resume at last stop
+        thread.data.openai.assistantThreadData.lastTimestamp = messagesToUploadElement.timestamp
       }
-      const assistantMessage = this.toAssistantMessage(messagesToUploadElement)
-      await client.beta.threads.messages.create(thread.data.openai.assistantThreadData.threadId, assistantMessage)
-      // update the marker in case of interruption to resume at last stop
-      thread.data.openai.assistantThreadData.lastTimestamp = messagesToUploadElement.timestamp
-    }
-    this.interactor.displayText(`Messages uploaded.`)
+      this.interactor.displayText(`Messages uploaded.`)
     } catch (error) {
       console.error('Error updating assistant thread:', error)
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       this.interactor.displayText(`\u26a0\ufe0f Error updating assistant thread: ${errorMessage}`)
       throw error // Re-throw to be caught by the calling function
     }
@@ -320,68 +320,68 @@ export class OpenaiClient extends AiClient {
     subscriber: Subject<CodayEvent>
   ): Promise<void> {
     try {
-    // Check interruption before starting stream processing
-    stream.on('textDone', (diff) => {
-      thread.data.openai.assistantThreadData.lastTimestamp = this.handleText(thread, diff.value, agent, subscriber)
-    })
-    for await (const chunk of stream) {
-      this.interactor.thinking()
-      if (chunk.event === 'thread.run.completed') {
-        const data = chunk.data as unknown as any
-        this.updateUsage(data?.usage, agent, thread)
-      }
+      // Check interruption before starting stream processing
+      stream.on('textDone', (diff) => {
+        thread.data.openai.assistantThreadData.lastTimestamp = this.handleText(thread, diff.value, agent, subscriber)
+      })
+      for await (const chunk of stream) {
+        this.interactor.thinking()
+        if (chunk.event === 'thread.run.completed') {
+          const data = chunk.data as unknown as any
+          this.updateUsage(data?.usage, agent, thread)
+        }
 
-      if (chunk.event === 'thread.run.requires_action') {
-        try {
-          const toolRequests =
-            chunk.data.required_action?.submit_tool_outputs.tool_calls?.map(
-              (toolCall) =>
-                new ToolRequestEvent({
-                  toolRequestId: toolCall.id,
-                  name: toolCall.function.name,
-                  args: toolCall.function.arguments,
+        if (chunk.event === 'thread.run.requires_action') {
+          try {
+            const toolRequests =
+              chunk.data.required_action?.submit_tool_outputs.tool_calls?.map(
+                (toolCall) =>
+                  new ToolRequestEvent({
+                    toolRequestId: toolCall.id,
+                    name: toolCall.function.name,
+                    args: toolCall.function.arguments,
+                  })
+              ) ?? []
+            const toolOutputs: RunSubmitToolOutputsParams.ToolOutput[] = []
+            await Promise.all(
+              toolRequests.map(async (request) => {
+                let responseEvent: ToolResponseEvent
+                try {
+                  responseEvent = await agent.tools.run(request)
+                } catch (error: any) {
+                  console.error(`Error running tool ${request.name}:`, error)
+                  responseEvent = request.buildResponse(`Error: ${error.message}`)
+                }
+                thread.addToolRequests(agent.name, [request])
+                thread.addToolResponseEvents([responseEvent])
+                toolOutputs.push({
+                  tool_call_id: request.toolRequestId,
+                  output: responseEvent.output,
                 })
-            ) ?? []
-          const toolOutputs: RunSubmitToolOutputsParams.ToolOutput[] = []
-          await Promise.all(
-            toolRequests.map(async (request) => {
-              let responseEvent: ToolResponseEvent
-              try {
-                responseEvent = await agent.tools.run(request)
-              } catch (error: any) {
-                console.error(`Error running tool ${request.name}:`, error)
-                responseEvent = request.buildResponse(`Error: ${error.message}`)
-              }
-              thread.addToolRequests(agent.name, [request])
-              thread.addToolResponseEvents([responseEvent])
-              toolOutputs.push({
-                tool_call_id: request.toolRequestId,
-                output: responseEvent.output,
               })
-            })
-          )
+            )
 
-          const newStream = client!.beta.threads.runs.submitToolOutputsStream(
-            thread.data.openai.assistantThreadData.threadId!,
-            chunk.data.id,
-            { tool_outputs: toolOutputs }
-          )
-          if (!this.shouldProceed(thread)) return
-          await this.processAssistantStream.call(this, newStream, agent, client, thread, subscriber)
-        } catch (error) {
-          console.error(`Error processing tool call`, error)
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-          this.interactor.displayText(`\u26a0\ufe0f Error processing tool call: ${errorMessage}`)
-          subscriber.next(
-            new ErrorEvent({
-              error: new Error(`Error processing OpenAI assistant tool call: ${errorMessage}`)
-            })
-          )
+            const newStream = client!.beta.threads.runs.submitToolOutputsStream(
+              thread.data.openai.assistantThreadData.threadId!,
+              chunk.data.id,
+              { tool_outputs: toolOutputs }
+            )
+            if (!this.shouldProceed(thread)) return
+            await this.processAssistantStream.call(this, newStream, agent, client, thread, subscriber)
+          } catch (error) {
+            console.error(`Error processing tool call`, error)
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+            this.interactor.displayText(`\u26a0\ufe0f Error processing tool call: ${errorMessage}`)
+            subscriber.next(
+              new ErrorEvent({
+                error: new Error(`Error processing OpenAI assistant tool call: ${errorMessage}`),
+              })
+            )
+          }
         }
       }
-    }
     } catch (error) {
-      this.handleError(error, subscriber, this.providerName);
+      this.handleError(error, subscriber, this.providerName)
     }
   }
 }


### PR DESCRIPTION
Add a simple prompt history management (not persisted yet, but it should be trivial to put if in ~/.coday/user/.../prompt_history.txt).
Trigger it with up/down arrows from first/last lines of input to recall your previous or next prompts in the current session.
Also added multiline input management in the terminal (Alt+Enter as in claude code, but we may want to align with the web and have cmd+enter submit...)