### PR TITLE
feat: add copy button for agent responses in web UI (#60)

### DIFF
--- a/apps/web/client/chat-history/chat-history.component.ts
+++ b/apps/web/client/chat-history/chat-history.component.ts
@@ -1,4 +1,4 @@
-import { AnswerEvent, CodayEvent, TextEvent, ThinkingEvent } from '@coday/shared/coday-events'
+import { AnswerEvent, CodayEvent, ErrorEvent, TextEvent, ThinkingEvent } from '@coday/shared/coday-events'
 import { CodayEventHandler } from '../utils/coday-event-handler'
 
 export class ChatHistoryComponent implements CodayEventHandler {
@@ -77,7 +77,47 @@ export class ChatHistoryComponent implements CodayEventHandler {
   addAnswer(answer: string, speaker: string | undefined): void {
     const newEntry = this.createMessageElement(answer, speaker)
     newEntry.classList.add('text', 'right')
+    
+    // Add copy button for agent responses
+    const copyButtonContainer = document.createElement('div')
+    copyButtonContainer.classList.add('copy-button-container')
+    
+    const copyButton = document.createElement('button')
+    copyButton.classList.add('copy-button')
+    copyButton.title = 'Copy raw response'
+    copyButton.textContent = '📋' // Clipboard icon
+    copyButton.addEventListener('click', (event) => {
+      event.stopPropagation() // Prevent event bubbling
+      this.copyToClipboard(answer)
+      // Update this specific button
+      const clickedButton = event.currentTarget as HTMLButtonElement
+      if (clickedButton) {
+        // Clear any existing active buttons
+        document.querySelectorAll('.copy-button.active').forEach(btn => {
+          btn.classList.remove('active')
+          btn.textContent = '📋'
+        })
+        
+        clickedButton.classList.add('active')
+        clickedButton.textContent = '✓' // Checkmark to indicate success
+        
+        // Reset button after 2 seconds
+        setTimeout(() => {
+          clickedButton.classList.remove('active')
+          clickedButton.textContent = '📋'
+        }, 2000)
+      }
+    })
+    
+    copyButtonContainer.appendChild(copyButton)
+    newEntry.appendChild(copyButtonContainer)
+    
     this.appendMessageElement(newEntry)
+  }
+  
+  private copyToClipboard(text: string): void {
+    navigator.clipboard.writeText(text)
+      .catch(err => console.error('Failed to copy text: ', err))
   }
 
   private createMessageElement(content: string, speaker: string | undefined): HTMLDivElement {

--- a/apps/web/client/chat-history/chat-history.component.ts
+++ b/apps/web/client/chat-history/chat-history.component.ts
@@ -71,12 +71,6 @@ export class ChatHistoryComponent implements CodayEventHandler {
   addText(text: string, speaker: string | undefined): void {
     const newEntry = this.createMessageElement(text, speaker)
     newEntry.classList.add('text', 'left')
-    this.appendMessageElement(newEntry)
-  }
-
-  addAnswer(answer: string, speaker: string | undefined): void {
-    const newEntry = this.createMessageElement(answer, speaker)
-    newEntry.classList.add('text', 'right')
     
     // Add copy button for agent responses
     const copyButtonContainer = document.createElement('div')
@@ -88,7 +82,8 @@ export class ChatHistoryComponent implements CodayEventHandler {
     copyButton.textContent = '📋' // Clipboard icon
     copyButton.addEventListener('click', (event) => {
       event.stopPropagation() // Prevent event bubbling
-      this.copyToClipboard(answer)
+      this.copyToClipboard(text)
+      
       // Update this specific button
       const clickedButton = event.currentTarget as HTMLButtonElement
       if (clickedButton) {
@@ -114,10 +109,15 @@ export class ChatHistoryComponent implements CodayEventHandler {
     
     this.appendMessageElement(newEntry)
   }
-  
+
+  addAnswer(answer: string, speaker: string | undefined): void {
+    const newEntry = this.createMessageElement(answer, speaker)
+    newEntry.classList.add('text', 'right')
+    this.appendMessageElement(newEntry)
+  }
+
   private copyToClipboard(text: string): void {
-    navigator.clipboard.writeText(text)
-      .catch(err => console.error('Failed to copy text: ', err))
+    navigator.clipboard.writeText(text).catch((err) => console.error('Failed to copy text: ', err))
   }
 
   private createMessageElement(content: string, speaker: string | undefined): HTMLDivElement {

--- a/apps/web/client/chat-history/chat-history.css
+++ b/apps/web/client/chat-history/chat-history.css
@@ -37,6 +37,7 @@
     align-self: flex-end;
     margin-left: 5em;
     background-color: var(--color-message-user);
+    position: relative;
 }
 
 .text.left {
@@ -118,4 +119,39 @@
     40% {
         opacity: 1;
     }
+}
+
+/* Copy button styles */
+.copy-button-container {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.text:hover .copy-button-container {
+    opacity: 1;
+}
+
+.copy-button {
+    background: var(--color-bg);
+    border: 1px solid var(--color-text-secondary);
+    border-radius: 4px;
+    padding: 4px 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-size: 14px;
+    color: var(--color-text);
+}
+
+.copy-button:hover {
+    background: var(--color-primary);
+    color: var(--color-bg);
+}
+
+.copy-button.active {
+    background: var(--color-success, #28a745);
+    color: white;
+    border-color: var(--color-success, #28a745);
 }

--- a/apps/web/client/chat-history/chat-history.css
+++ b/apps/web/client/chat-history/chat-history.css
@@ -37,12 +37,12 @@
     align-self: flex-end;
     margin-left: 5em;
     background-color: var(--color-message-user);
-    position: relative;
 }
 
 .text.left {
     align-self: flex-start;
     margin-right: 5em;
+    position: relative;
 }
 
 .text:last-child {


### PR DESCRIPTION
The copy button copies the raw response of the agent to the clipboard, by-passing the rendered markdown.