### PR TITLE
fix: agent selection from thread

### DIFF
--- a/libs/ai-thread/ai-thread.ts
+++ b/libs/ai-thread/ai-thread.ts
@@ -309,6 +309,19 @@ export class AiThread {
     return this.price + (this.parentThread?.totalPrice ?? 0)
   }
 
+  /**
+   * Returns the name of the last agent (assistant) that responded in this thread, or undefined if none.
+   */
+  getLastAgentName(): string | undefined {
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      const msg = this.messages[i];
+      if (msg instanceof MessageEvent && msg.role === 'assistant' && msg.name) {
+        return msg.name;
+      }
+    }
+    return undefined;
+  }
+
   addToolRequests(agentName: string, toolRequests: ToolRequestEvent[]): void {
     toolRequests.forEach((toolRequest) => {
       if (!toolRequest.toolRequestId || !toolRequest.name || !toolRequest.args) return


### PR DESCRIPTION
Get the last selected agent from the aiThread history instead of the property `lastAgentName`.

This should fix corner-cases where agent selection was lost, and be robust to thread re-loading silently or explicitly.