### PR TITLE
feat: Display tool request and response events in UI

### DIFF
--- a/apps/terminal/terminal-interactor.ts
+++ b/apps/terminal/terminal-interactor.ts
@@ -8,6 +8,8 @@ import {
   InviteEvent,
   TextEvent,
   ThinkingEvent,
+  ToolRequestEvent,
+  ToolResponseEvent,
   WarnEvent,
 } from '@coday/shared/coday-events'
 import * as readline from 'node:readline'
@@ -53,6 +55,12 @@ export class TerminalInteractor extends Interactor {
       }
       if (event instanceof ThinkingEvent) {
         process.stdout.write(chalk.blue('.'))
+      }
+      if (event instanceof ToolRequestEvent) {
+        console.log(chalk.cyan(event.toSingleLineString()))
+      }
+      if (event instanceof ToolResponseEvent) {
+        console.log(chalk.cyan(event.toSingleLineString()))
       }
     })
 

--- a/apps/web/client/chat-history/chat-history.component.ts
+++ b/apps/web/client/chat-history/chat-history.component.ts
@@ -193,13 +193,63 @@ export class ChatHistoryComponent implements CodayEventHandler {
 
 
 
+  private getClientId(): string {
+    // Extract clientId from URL
+    const params = new URLSearchParams(window.location.search)
+    return params.get('clientId') || ''
+  }
+
   addToolRequest(event: ToolRequestEvent): void {
-    // Use the event's built-in formatting method
-    this.addTechnical(event.toSingleLineString())
+    // Create a message element with the tool request
+    const messageText = event.toSingleLineString()
+    const element = document.createElement('div')
+    element.classList.add('message', 'technical')
+    
+    // Create the message span
+    const messageSpan = document.createElement('span')
+    messageSpan.textContent = messageText
+    element.appendChild(messageSpan)
+    
+    // Create a link to view full details
+    const clientId = this.getClientId()
+    if (clientId) {
+      const link = document.createElement('a')
+      link.href = event.getDetailsUrl(clientId)
+      link.textContent = ' [View Full]'
+      link.target = '_blank'
+      link.style.marginLeft = '5px'
+      link.style.fontSize = '0.9em'
+      link.style.color = 'var(--color-link)'
+      element.appendChild(link)
+    }
+    
+    this.appendMessageElement(element)
   }
 
   addToolResponse(event: ToolResponseEvent): void {
-    // Use the event's built-in formatting method
-    this.addTechnical(event.toSingleLineString())
+    // Create a message element with the tool response
+    const messageText = event.toSingleLineString()
+    const element = document.createElement('div')
+    element.classList.add('message', 'technical')
+    
+    // Create the message span
+    const messageSpan = document.createElement('span')
+    messageSpan.textContent = messageText
+    element.appendChild(messageSpan)
+    
+    // Create a link to view full details
+    const clientId = this.getClientId()
+    if (clientId) {
+      const link = document.createElement('a')
+      link.href = event.getDetailsUrl(clientId)
+      link.textContent = ' [View Full]'
+      link.target = '_blank'
+      link.style.marginLeft = '5px'
+      link.style.fontSize = '0.9em'
+      link.style.color = 'var(--color-link)'
+      element.appendChild(link)
+    }
+    
+    this.appendMessageElement(element)
   }
 }

--- a/apps/web/client/chat-history/chat-history.component.ts
+++ b/apps/web/client/chat-history/chat-history.component.ts
@@ -1,4 +1,12 @@
-import { AnswerEvent, CodayEvent, ErrorEvent, TextEvent, ThinkingEvent } from '@coday/shared/coday-events'
+import {
+  AnswerEvent,
+  CodayEvent,
+  ErrorEvent,
+  TextEvent,
+  ThinkingEvent,
+  ToolRequestEvent,
+  ToolResponseEvent,
+} from '@coday/shared/coday-events'
 import { CodayEventHandler } from '../utils/coday-event-handler'
 
 export class ChatHistoryComponent implements CodayEventHandler {
@@ -40,6 +48,12 @@ export class ChatHistoryComponent implements CodayEventHandler {
     if (event instanceof ThinkingEvent) {
       this.setThinking(true)
     }
+    if (event instanceof ToolRequestEvent) {
+      this.addToolRequest(event)
+    }
+    if (event instanceof ToolResponseEvent) {
+      this.addToolResponse(event)
+    }
   }
 
   private setThinking(value: boolean): void {
@@ -71,11 +85,11 @@ export class ChatHistoryComponent implements CodayEventHandler {
   addText(text: string, speaker: string | undefined): void {
     const newEntry = this.createMessageElement(text, speaker)
     newEntry.classList.add('text', 'left')
-    
+
     // Add copy button for agent responses
     const copyButtonContainer = document.createElement('div')
     copyButtonContainer.classList.add('copy-button-container')
-    
+
     const copyButton = document.createElement('button')
     copyButton.classList.add('copy-button')
     copyButton.title = 'Copy raw response'
@@ -83,19 +97,19 @@ export class ChatHistoryComponent implements CodayEventHandler {
     copyButton.addEventListener('click', (event) => {
       event.stopPropagation() // Prevent event bubbling
       this.copyToClipboard(text)
-      
+
       // Update this specific button
       const clickedButton = event.currentTarget as HTMLButtonElement
       if (clickedButton) {
         // Clear any existing active buttons
-        document.querySelectorAll('.copy-button.active').forEach(btn => {
+        document.querySelectorAll('.copy-button.active').forEach((btn) => {
           btn.classList.remove('active')
           btn.textContent = '📋'
         })
-        
+
         clickedButton.classList.add('active')
         clickedButton.textContent = '✓' // Checkmark to indicate success
-        
+
         // Reset button after 2 seconds
         setTimeout(() => {
           clickedButton.classList.remove('active')
@@ -103,10 +117,10 @@ export class ChatHistoryComponent implements CodayEventHandler {
         }, 2000)
       }
     })
-    
+
     copyButtonContainer.appendChild(copyButton)
     newEntry.appendChild(copyButtonContainer)
-    
+
     this.appendMessageElement(newEntry)
   }
 
@@ -175,5 +189,17 @@ export class ChatHistoryComponent implements CodayEventHandler {
 
     this.chatHistory?.appendChild(errorEntry)
     this.scrollToBottom()
+  }
+
+
+
+  addToolRequest(event: ToolRequestEvent): void {
+    // Use the event's built-in formatting method
+    this.addTechnical(event.toSingleLineString())
+  }
+
+  addToolResponse(event: ToolResponseEvent): void {
+    // Use the event's built-in formatting method
+    this.addTechnical(event.toSingleLineString())
   }
 }

--- a/apps/web/client/chat-history/chat-history.component.ts
+++ b/apps/web/client/chat-history/chat-history.component.ts
@@ -191,65 +191,68 @@ export class ChatHistoryComponent implements CodayEventHandler {
     this.scrollToBottom()
   }
 
-
-
   private getClientId(): string {
     // Extract clientId from URL
     const params = new URLSearchParams(window.location.search)
     return params.get('clientId') || ''
   }
 
+  private createViewFullLink(eventId: string): HTMLAnchorElement | null {
+    const clientId = this.getClientId()
+    if (!clientId) return null
+
+    const link = document.createElement('a')
+    link.href = `/api/event/${eventId}?clientId=${clientId}`
+    link.textContent = 'view'
+    link.target = '_blank'
+    link.style.marginLeft = '5px'
+    link.style.fontSize = '0.9em'
+    link.style.color = 'var(--color-link)'
+
+    return link
+  }
+
   addToolRequest(event: ToolRequestEvent): void {
     // Create a message element with the tool request
-    const messageText = event.toSingleLineString()
     const element = document.createElement('div')
     element.classList.add('message', 'technical')
-    
-    // Create the message span
-    const messageSpan = document.createElement('span')
-    messageSpan.textContent = messageText
-    element.appendChild(messageSpan)
-    
-    // Create a link to view full details
-    const clientId = this.getClientId()
-    if (clientId) {
-      const link = document.createElement('a')
-      link.href = event.getDetailsUrl(clientId)
-      link.textContent = ' [View Full]'
-      link.target = '_blank'
-      link.style.marginLeft = '5px'
-      link.style.fontSize = '0.9em'
-      link.style.color = 'var(--color-link)'
-      element.appendChild(link)
+
+    // Create the container span
+    const container = document.createElement('span')
+
+    // Add the message text as a text node
+    const messageText = event.toSingleLineString()
+    container.appendChild(document.createTextNode(messageText))
+
+    // Add link at the end of the message
+    const link = this.createViewFullLink(event.timestamp)
+    if (link) {
+      container.appendChild(link)
     }
-    
+
+    element.appendChild(container)
     this.appendMessageElement(element)
   }
 
   addToolResponse(event: ToolResponseEvent): void {
     // Create a message element with the tool response
-    const messageText = event.toSingleLineString()
     const element = document.createElement('div')
     element.classList.add('message', 'technical')
-    
-    // Create the message span
-    const messageSpan = document.createElement('span')
-    messageSpan.textContent = messageText
-    element.appendChild(messageSpan)
-    
-    // Create a link to view full details
-    const clientId = this.getClientId()
-    if (clientId) {
-      const link = document.createElement('a')
-      link.href = event.getDetailsUrl(clientId)
-      link.textContent = ' [View Full]'
-      link.target = '_blank'
-      link.style.marginLeft = '5px'
-      link.style.fontSize = '0.9em'
-      link.style.color = 'var(--color-link)'
-      element.appendChild(link)
+
+    // Create the container span
+    const container = document.createElement('span')
+
+    // Add the message text as a text node
+    const messageText = event.toSingleLineString()
+    container.appendChild(document.createTextNode(messageText))
+
+    // Add link at the end of the message
+    const link = this.createViewFullLink(event.timestamp)
+    if (link) {
+      container.appendChild(link)
     }
-    
+
+    element.appendChild(container)
     this.appendMessageElement(element)
   }
 }

--- a/apps/web/client/styles/colors.css
+++ b/apps/web/client/styles/colors.css
@@ -18,6 +18,7 @@
     /* Interactive Elements */
     --color-primary: #7064fb;
     --color-primary-hover: #ff79c6;
+    --color-link: #3498db;
     --color-border: #aeaeae;
     --color-input-bg: #ffffff;
 
@@ -49,6 +50,7 @@
     /* Interactive Elements */
     --color-primary: #e4d1ff;
     --color-primary-hover: #ff79c6;
+    --color-link: #61afef;
     --color-border: #6272a4;
     --color-input-bg: #282a36;
 

--- a/apps/web/server/server-client.ts
+++ b/apps/web/server/server-client.ts
@@ -172,6 +172,19 @@ export class ServerClient {
   getInteractor(): ServerInteractor {
     return this.interactor
   }
+  
+  /**
+   * Get an event by its ID from the current thread
+   * @param eventId The ID (timestamp) of the event to retrieve
+   * @returns The event if found, undefined otherwise
+   */
+  getEventById(eventId: string): any {
+    if (!this.coday?.context?.aiThread) {
+      return undefined
+    }
+    
+    return this.coday.context.aiThread.getEventById(eventId)
+  }
 
   private cleanup(): void {
     debugLog('CLIENT', `Starting cleanup for client ${this.clientId}`)

--- a/libs/ai-thread/ai-thread.ts
+++ b/libs/ai-thread/ai-thread.ts
@@ -321,6 +321,15 @@ export class AiThread {
     }
     return undefined;
   }
+  
+  /**
+   * Gets an event by its timestamp ID
+   * @param eventId The timestamp ID of the event to retrieve
+   * @returns The event if found, undefined otherwise
+   */
+  getEventById(eventId: string): ThreadMessage | undefined {
+    return this.messages.find(msg => msg.timestamp === eventId);
+  }
 
   addToolRequests(agentName: string, toolRequests: ToolRequestEvent[]): void {
     toolRequests.forEach((toolRequest) => {

--- a/libs/coday.ts
+++ b/libs/coday.ts
@@ -8,7 +8,7 @@ import { selectAiThread } from './handler/ai-thread/select-ai-thread'
 import { AiClientProvider } from './integration/ai/ai-client-provider'
 import { keywords } from './keywords'
 import { CommandContext, Interactor } from './model'
-import { AnswerEvent, MessageEvent, TextEvent } from './shared/coday-events'
+import { AnswerEvent, MessageEvent, TextEvent, ToolRequestEvent, ToolResponseEvent } from './shared/coday-events'
 import { AgentService } from './agent'
 import { CodayOptions } from './options'
 import { CodayServices } from './coday-services'
@@ -58,11 +58,14 @@ export class Coday {
 
     // Convert and emit each message
     for (const message of sortedMessages) {
-      if (!(message instanceof MessageEvent)) continue
-      if (message.role === 'assistant') {
-        this.interactor.sendEvent(new TextEvent({ ...message, speaker: message.name, text: message.content }))
-      } else {
-        this.interactor.sendEvent(new AnswerEvent({ ...message, answer: message.content, invite: message.name }))
+      if (message instanceof MessageEvent) {
+        if (message.role === 'assistant') {
+          this.interactor.sendEvent(new TextEvent({ ...message, speaker: message.name, text: message.content }))
+        } else {
+          this.interactor.sendEvent(new AnswerEvent({ ...message, answer: message.content, invite: message.name }))
+        }
+      } else if (message instanceof ToolRequestEvent || message instanceof ToolResponseEvent) {
+        this.interactor.sendEvent(message)
       }
     }
 

--- a/libs/handler/openai.client.ts
+++ b/libs/handler/openai.client.ts
@@ -347,7 +347,9 @@ export class OpenaiClient extends AiClient {
               toolRequests.map(async (request) => {
                 let responseEvent: ToolResponseEvent
                 try {
+                  this.interactor.sendEvent(request)
                   responseEvent = await agent.tools.run(request)
+                  this.interactor.sendEvent(responseEvent)
                 } catch (error: any) {
                   console.error(`Error running tool ${request.name}:`, error)
                   responseEvent = request.buildResponse(`Error: ${error.message}`)

--- a/libs/model/ai.client.ts
+++ b/libs/model/ai.client.ts
@@ -1,10 +1,10 @@
-import {Observable, Subject} from 'rxjs'
-import {CodayEvent, ErrorEvent, MessageEvent, ToolRequestEvent, ToolResponseEvent} from '../shared/coday-events'
-import {Agent} from './agent'
-import {AiThread} from '../ai-thread/ai-thread'
-import {RunStatus} from '../ai-thread/ai-thread.types'
-import {Interactor} from './interactor'
-import {ModelSize} from './agent-definition'
+import { Observable, Subject } from 'rxjs'
+import { CodayEvent, ErrorEvent, MessageEvent, ToolRequestEvent, ToolResponseEvent } from '../shared/coday-events'
+import { Agent } from './agent'
+import { AiThread } from '../ai-thread/ai-thread'
+import { RunStatus } from '../ai-thread/ai-thread.types'
+import { Interactor } from './interactor'
+import { ModelSize } from './agent-definition'
 
 /**
  * Common abstraction over different AI provider APIs.
@@ -112,7 +112,9 @@ export abstract class AiClient {
       toolRequests.map(async (request) => {
         let responseEvent: ToolResponseEvent
         try {
+          this.interactor.sendEvent(request)
           responseEvent = await agent.tools.run(request)
+          this.interactor.sendEvent(responseEvent)
         } catch (error: any) {
           console.error(`Error running tool ${request.name}:`, error)
           responseEvent = request.buildResponse(`Error: ${error.message}`)

--- a/libs/shared/coday-events.ts
+++ b/libs/shared/coday-events.ts
@@ -1,3 +1,31 @@
+/**
+ * Helper function to truncate text for display
+ * @param text Text to truncate
+ * @param maxLength Maximum length before truncation
+ * @returns Truncated text with ellipsis if needed
+ */
+export function truncateText(text: string, maxLength: number = 80): string {
+  // If it's already a short string, return as is
+  if (text.length <= maxLength) return text
+
+  // Try to parse as JSON to handle objects and arrays better
+  try {
+    // If it starts with { or [, assume it's JSON
+    if (text.trim().startsWith('{') || text.trim().startsWith('[')) {
+      const obj = JSON.parse(text)
+      // For simple display, just stringify with minimal formatting
+      const simplified = JSON.stringify(obj)
+      if (simplified.length <= maxLength) return simplified
+      return simplified.substring(0, maxLength) + `...(${simplified.length} chars)`
+    }
+  } catch (e) {
+    // Not valid JSON or other error, fall back to simple truncation
+  }
+
+  // Default: simple truncation
+  return text.substring(0, maxLength) + '...'
+}
+
 export abstract class CodayEvent {
   timestamp: string
   parentKey: string | undefined
@@ -118,6 +146,16 @@ export class ToolRequestEvent extends CodayEvent {
   buildResponse(output: string): ToolResponseEvent {
     return new ToolResponseEvent({ output, toolRequestId: this.toolRequestId })
   }
+
+  /**
+   * Renders the tool request as a single line string with truncation
+   * @param maxLength Maximum length for the arguments before truncation
+   * @returns A formatted string representation
+   */
+  toSingleLineString(maxLength: number = 50): string {
+    const truncatedArgs = truncateText(this.args, maxLength)
+    return `🔧 ${this.name}(${truncatedArgs})`
+  }
 }
 
 export class ToolResponseEvent extends CodayEvent {
@@ -130,6 +168,16 @@ export class ToolResponseEvent extends CodayEvent {
     this.toolRequestId = event.toolRequestId!!
     this.output = event.output!!
     this.length = this.output.length + this.toolRequestId.length + 20
+  }
+
+  /**
+   * Renders the tool response as a single line string with truncation
+   * @param maxLength Maximum length for the output before truncation
+   * @returns A formatted string representation
+   */
+  toSingleLineString(maxLength: number = 50): string {
+    const truncatedOutput = truncateText(this.output, maxLength)
+    return `📄 Result: ${truncatedOutput}`
   }
 }
 

--- a/libs/shared/coday-events.ts
+++ b/libs/shared/coday-events.ts
@@ -38,10 +38,10 @@ export abstract class CodayEvent {
   ) {
     // If timestamp is not provided, generate one with a random suffix to avoid collisions
     if (!event.timestamp) {
-      const randomSuffix = Math.random().toString(36).substring(2, 7); // 5 random chars
-      this.timestamp = `${new Date().toISOString()}-${randomSuffix}`;
+      const randomSuffix = Math.random().toString(36).substring(2, 7) // 5 random chars
+      this.timestamp = `${new Date().toISOString()}-${randomSuffix}`
     } else {
-      this.timestamp = event.timestamp;
+      this.timestamp = event.timestamp
     }
     this.parentKey = event.parentKey
     this.length = 0
@@ -163,15 +163,6 @@ export class ToolRequestEvent extends CodayEvent {
     const truncatedArgs = truncateText(this.args, maxLength)
     return `🔧 ${this.name}(${truncatedArgs})`
   }
-
-  /**
-   * Generates a URL to view the full event details
-   * @param clientId The client ID for API routing
-   * @returns A URL to view the full event
-   */
-  getDetailsUrl(clientId: string): string {
-    return `/api/event/${this.timestamp}?clientId=${clientId}`
-  }
 }
 
 export class ToolResponseEvent extends CodayEvent {
@@ -193,16 +184,7 @@ export class ToolResponseEvent extends CodayEvent {
    */
   toSingleLineString(maxLength: number = 50): string {
     const truncatedOutput = truncateText(this.output, maxLength)
-    return `📄 Result: ${truncatedOutput}`
-  }
-
-  /**
-   * Generates a URL to view the full event details
-   * @param clientId The client ID for API routing
-   * @returns A URL to view the full event
-   */
-  getDetailsUrl(clientId: string): string {
-    return `/api/event/${this.timestamp}?clientId=${clientId}`
+    return `⮑ ${truncatedOutput}`
   }
 }
 


### PR DESCRIPTION
## Description

This PR adds support for displaying tool request and response events in the UI with access to full details.

### Changes

1. **Display Tool Events in UI**:
   - Added handlers for `ToolRequestEvent` and `ToolResponseEvent` in the `ChatHistoryComponent`
   - Used compact single-line display with truncation for readability
   - Added "View Full" links to access complete event details in a new tab

2. **Backend Support**:
   - Added an API endpoint (`/api/event/:eventId`) to serve full event details
   - Added method to `AiThread` to retrieve events by ID
   - Added method to `ServerClient` to access events

3. **Fixed Timestamp Collisions**:
   - Added random suffix to event timestamps to ensure uniqueness
   - This prevents collisions when multiple events are created in quick succession
   - Fixed toolRequestId handling to use the unique timestamp

4. **Terminal Support**:
   - Updated the terminal interface to display tool events consistently

### Benefits

- Users can see when tools are being called and what results they return
- Full details are accessible when needed without cluttering the main UI
- The same formatting is used across web and terminal interfaces
- Tool events are properly included when replaying a thread after reconnection

### Implementation Notes

- Used a simple, minimalist approach focused on readability
- Kept UI concerns separate from core event classes
- Added proper error handling for edge cases
- Maintained consistent styling with existing technical messages