### PR TITLE
feat: clean tool logs

### DIFF
--- a/libs/handler-looper.ts
+++ b/libs/handler-looper.ts
@@ -100,6 +100,7 @@ export class HandlerLooper {
             this.formatHelp(keywords.reset, "resets Coday's context."),
             this.formatHelp(keywords.exit, 'quits the program.'),
           ]
+          // Keep this as displayText since help output is explicitly for the user
           this.interactor.displayText(handlerHelpMessages.join('\n'))
           continue
         }

--- a/libs/handler/file-map.handler.ts
+++ b/libs/handler/file-map.handler.ts
@@ -1,6 +1,6 @@
 import { CommandContext, CommandHandler, Interactor } from '../model'
 import { generateFileTree } from '../function/generate-file-tree'
-import path from 'path'
+import * as path from 'path'
 
 export class FileMapHandler extends CommandHandler {
   constructor(private interactor: Interactor) {
@@ -25,7 +25,7 @@ export class FileMapHandler extends CommandHandler {
     const chunkCount = fileTreeChunks.length
     for (let i = 0; i < chunkCount; i++) {
       context.aiThread?.addUserMessage(context.username, fileTreeChunks[i])
-      this.interactor.displayText(`Sent chunk ${i + 1} of ${chunkCount}`)
+      this.interactor.debug(`Sent chunk ${i + 1} of ${chunkCount}`)
     }
 
     return context

--- a/libs/handler/openai/ai.handler.ts
+++ b/libs/handler/openai/ai.handler.ts
@@ -19,10 +19,11 @@ export class AiHandler extends CommandHandler implements Killable {
 
   async handle(command: string, context: CommandContext): Promise<CommandContext> {
     const [agentName, restOfCommand] = parseAgentCommand(command)
+    this.interactor.debug(`Agent name extracted from command: ${agentName}`)
 
     // Try to select the specified agent
     // If agentName is empty, selectAgent will handle the fallback logic
-    const selectedAgent = await this.selectAgent(agentName.toLowerCase(), context)
+    const selectedAgent = await this.selectAgent(agentName, context)
 
     if (!selectedAgent) {
       this.interactor.error('Failed to find any agent')
@@ -47,7 +48,7 @@ export class AiHandler extends CommandHandler implements Killable {
    */
   private async selectAgent(nameStart: string, context: CommandContext): Promise<Agent | undefined> {
     // If a specific agent name start is provided, use that
-    if (nameStart?.trim()) {
+    if (nameStart) {
       const agent = await this.agentService.findAgentByNameStart(nameStart, context)
       if (agent) {
         this.interactor.debug(`Selected agent: ${agent.name}`)

--- a/libs/handler/openai/ai.handler.ts
+++ b/libs/handler/openai/ai.handler.ts
@@ -106,7 +106,7 @@ export class AiHandler extends CommandHandler implements Killable {
       },
       error: (error) => {
         if (error.message === 'Processing interrupted by user request') {
-          this.interactor.displayText('Processing stopped gracefully', agent.name)
+          this.interactor.debug('Processing stopped gracefully')
         } else {
           this.interactor.error(`Error in AI processing: ${error.message}`)
         }

--- a/libs/handler/openai/parseAgentCommand.test.ts
+++ b/libs/handler/openai/parseAgentCommand.test.ts
@@ -2,15 +2,15 @@ import { parseAgentCommand } from './parseAgentCommand'
 
 describe('parseAgentCommand', () => {
   it('parses simple agent command with command string', () => {
-    expect(parseAgentCommand('@AgentName rest of command')).toEqual(['AgentName', 'rest of command'])
+    expect(parseAgentCommand('@AgentName rest of command')).toEqual(['agentname', 'rest of command'])
   })
 
   it('parses agent command with newline', () => {
-    expect(parseAgentCommand('@AgentName\nrest of command')).toEqual(['AgentName', 'rest of command'])
+    expect(parseAgentCommand('@AgentName\nrest of command')).toEqual(['agentname', 'rest of command'])
   })
 
   it('parses agent name only', () => {
-    expect(parseAgentCommand('@AgentName')).toEqual(['AgentName', ''])
+    expect(parseAgentCommand('@AgentName')).toEqual(['agentname', ''])
   })
 
   it('parses only @', () => {
@@ -30,7 +30,7 @@ describe('parseAgentCommand', () => {
   })
 
   it('parses @name with multiple spaces before rest', () => {
-    expect(parseAgentCommand('@AgentName   lots of spaces')).toEqual(['AgentName', 'lots of spaces'])
+    expect(parseAgentCommand('@AgentName   lots of spaces')).toEqual(['agentname', 'lots of spaces'])
   })
 
   it('handles empty string', () => {

--- a/libs/handler/openai/parseAgentCommand.ts
+++ b/libs/handler/openai/parseAgentCommand.ts
@@ -12,8 +12,8 @@
 export function parseAgentCommand(command: string): [string, string] {
   // Format: @ followed by zero or more non-whitespace characters, optionally followed by whitespace and the rest
   const match = command.match(/^@(\S*)(?:\s+(.*))?$/)
-  if (!match) return ["", command]
+  if (!match) return ['', command]
   const agentName = match[1]
-  const restOfCommand = match[2] || ""
-  return [agentName, restOfCommand]
+  const restOfCommand = match[2] || ''
+  return [agentName?.toLowerCase(), restOfCommand]
 }

--- a/libs/integration/ai/ai.tools.ts
+++ b/libs/integration/ai/ai.tools.ts
@@ -57,7 +57,7 @@ export class AiTools extends AssistantToolFactory {
 
     if (!context.oneshot) {
       // Add redirect tool
-      const redirect = redirectFunction({ context, interactor: this.interactor, agentService: this.agentService })
+      const redirect = redirectFunction({ context, agentService: this.agentService })
 
       const agentSummaries = this.agentService
         .listAgentSummaries()

--- a/libs/integration/ai/delegate.function.ts
+++ b/libs/integration/ai/delegate.function.ts
@@ -15,19 +15,14 @@ export function delegateFunction(input: DelegateInput) {
   const delegate = async ({ task, agentName }: { task: string; agentName: string | undefined }) => {
     try {
       if (context.stackDepth <= 0) {
-        interactor.displayText('Delegation denied further.')
         return 'Delegation not allowed, either permanently, or existing capacity already used.'
       }
 
-      interactor.displayText(`DELEGATING to agent ${agentName} the task:\n${task}`)
       const agent: Agent | undefined = await agentService.findAgentByNameStart(agentName, context)
 
       if (!agent) {
-        const output = `Agent ${agentName} not found.`
-        interactor.displayText(output)
-        return output
+        return `Agent ${agentName} not found.`
       }
-      console.log(`Agent identified: ${agent?.name}`)
 
       const forkedThread: AiThread = context.aiThread!.fork(agentName ? agent.name : undefined)
       const formattedTask: string = `You were delegated a task to try to complete the best you can.
@@ -61,7 +56,7 @@ The parent conversation (all previous messages) is there for context, but your c
       return result.content
     } catch (error: any) {
       console.error('Error in delegate function:', error)
-      interactor.displayText(`Error during delegation: ${error.message}`)
+      interactor.error(`Error during delegation: ${error.message}`)
       return `Error during delegation: ${error.message}`
     }
   }

--- a/libs/integration/ai/delegate.tools.ts
+++ b/libs/integration/ai/delegate.tools.ts
@@ -52,10 +52,12 @@ export class DelegateTools extends AssistantToolFactory {
       agentService: this.agentService,
     })
     const delegateWithAllowList = async ({ task, agentName }: { task: string; agentName: string | undefined }) => {
-      if (allowList && (!agentName || !allowList.includes(agentName))) {
+      if (allowList && (!agentName || !allowList.includes(agentName.toLowerCase()))) {
+        this.interactor.debug(`allowList: ${allowList.join(', ')}`)
         const msg = agentName
           ? `Delegation denied: agent '${agentName}' is not allowed for delegation.`
           : `Delegation denied: no agent selected and delegation is restricted.`
+        // Keep as displayText as this is an important user-facing error message
         this.interactor.displayText(msg)
         return msg
       }

--- a/libs/integration/ai/redirect.function.ts
+++ b/libs/integration/ai/redirect.function.ts
@@ -1,31 +1,26 @@
-import { CommandContext, Interactor } from '../../model'
+import { CommandContext } from '../../model'
 import { AgentService } from '../../agent'
 
 type RedirectInput = {
   context: CommandContext
-  interactor: Interactor
   agentService: AgentService
 }
 
 export function redirectFunction(input: RedirectInput) {
-  const { context, interactor } = input
-  
+  const { context } = input
+
   const redirect = ({ query, agentName }: { query: string; agentName: string }) => {
     try {
-      interactor.displayText(`REDIRECTING query to agent ${agentName}:\n${query}`)
-      
       // Add a command to the queue that will be processed after this run completes
       // The format is "@agentName query" which is the standard format for agent invocation
       const command = `@${agentName} ${query}`
       context.addCommands(command)
-      
+
       return `Query successfully redirected to agent '${agentName}'. The agent will process the query with full context after this run completes.`
     } catch (error: any) {
-      console.error('Error in redirect function:', error)
-      interactor.displayText(`Error during redirection: ${error.message}`)
       return `Error during redirection: ${error.message}`
     }
   }
-  
+
   return redirect
 }

--- a/libs/integration/file/find-files-by-text.ts
+++ b/libs/integration/file/find-files-by-text.ts
@@ -33,7 +33,7 @@ export const findFilesByText = async ({
   const searchPath = path ?? '.'
   const searchCommand = `rg "${escapedText}" ${searchPath} ${fileTypePattern} --color never -l`
 
-  interactor.displayText(`\nExecuting search command: ${searchCommand}`)
+  interactor.debug(`Executing search command: ${searchCommand}`)
 
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {

--- a/libs/integration/file/write-file-chunk.ts
+++ b/libs/integration/file/write-file-chunk.ts
@@ -21,8 +21,6 @@ export const writeFileChunk = ({ relPath, root, interactor, replacements }: Writ
   const fullPath = relPath ? path.resolve(root, relPath) : root
 
   try {
-    // Notify the beginning of the write operation
-    interactor.displayText(`Partial write on file ${fullPath}`)
     // Check if the file exists
     if (!existsSync(fullPath)) {
       const errorMessage = `No file found at ${fullPath}`
@@ -71,8 +69,6 @@ export const writeFileChunk = ({ relPath, root, interactor, replacements }: Writ
     } else {
       message = `File edited with the following results:\n${message}`
     }
-
-    interactor.displayText(message)
 
     // Return the final outcome message
     return message

--- a/libs/integration/jira/jira.tools.ts
+++ b/libs/integration/jira/jira.tools.ts
@@ -40,7 +40,7 @@ export class JiraTools extends AssistantToolFactory {
     }
 
     const retrieveIssue = ({ ticketId }: { ticketId: string }) => {
-      return retrieveJiraIssue(ticketId, jiraBaseUrl, jiraApiToken, jiraUsername, this.interactor)
+      return retrieveJiraIssue(ticketId, jiraBaseUrl, jiraApiToken, jiraUsername)
     }
     const retrieveJiraTicketFunction: FunctionTool<{
       ticketId: string

--- a/libs/integration/jira/retrieve-jira-issue.ts
+++ b/libs/integration/jira/retrieve-jira-issue.ts
@@ -1,30 +1,25 @@
 import axios from 'axios'
-import { Interactor } from '../../model'
 
 export async function retrieveJiraIssue(
   ticketId: string,
   jiraBaseUrl: string,
   jiraApiToken: string,
-  jiraUsername: string,
-  interactor: Interactor
+  jiraUsername: string
 ): Promise<any> {
   if (!jiraBaseUrl || !jiraApiToken || !jiraUsername) {
     throw new Error('Jira integration incorrectly set')
   }
 
   try {
-    interactor.displayText(`Fetching JIRA ticket ${ticketId}...`)
     const response = await axios.get(`${jiraBaseUrl}/rest/api/2/issue/${ticketId}`, {
       auth: {
         username: jiraUsername,
         password: jiraApiToken,
       },
     })
-    interactor.displayText(`... got JIRA response.`)
 
     return response.data
   } catch (error: any) {
-    interactor.warn(`Failed to retrieve Jira ticket `)
     return `Failed to retrieve Jira ticket with ID ${ticketId}: ${error.message}`
   }
 }

--- a/libs/integration/memory.tools.ts
+++ b/libs/integration/memory.tools.ts
@@ -23,7 +23,6 @@ export class MemoryTools extends AssistantToolFactory {
       const parsedLevel: MemoryLevel = level === 'USER' ? MemoryLevel.USER : MemoryLevel.PROJECT
 
       this.memoryService.upsertMemory({ title, content, level: parsedLevel, agentName })
-      this.interactor.displayText(`Added ${parsedLevel} memory : ${title}\n${content}`)
       return `Memory added with title: ${title}`
     }
 
@@ -70,7 +69,6 @@ Do not memorize partial knowledge, single-use information, or minor implementati
     const deleteMemoryFunction = async ({ title }: { title: string }) => {
       try {
         this.memoryService.deleteMemory(title)
-        this.interactor.displayText(`Deleted memory: ${title}`)
         return `Memory deleted: ${title}`
       } catch (error) {
         const errorMessage = `Failed to delete memory: ${error instanceof Error ? error.message : 'Unknown error'}`


### PR DESCRIPTION
Tool call requests and responses are logged => removing duplicate `displayText` when not necessary.

Fixed a glitch in the delegate tool.