### PR TITLE
fix: thread truncating for context window

### DIFF
--- a/apps/web/client/header/header.component.ts
+++ b/apps/web/client/header/header.component.ts
@@ -1,4 +1,3 @@
-
 import { CodayEvent, ProjectSelectedEvent } from '@coday/coday-events'
 import { CodayEventHandler } from '../utils/coday-event-handler'
 
@@ -7,8 +6,7 @@ export class HeaderComponent implements CodayEventHandler {
 
   handle(event: CodayEvent): void {
     if (event instanceof ProjectSelectedEvent) {
-      const projectSuffix = event.projectName ? ` (${event.projectName})` : ''
-      const title = `Coday${projectSuffix}`
+      const title = event.projectName || `Coday`
       document.title = title
       this.headerTitle.innerHTML = title
     }

--- a/libs/ai-thread/ai-thread.helpers.test.ts
+++ b/libs/ai-thread/ai-thread.helpers.test.ts
@@ -33,4 +33,28 @@ describe('partition', () => {
     expect(result.messages.length).toBe(0)
     expect(result.overflow.length).toBe(4)
   })
+  it('should partially overflow with max after msg1', () => {
+    const length = message1.length + 1
+    const result = partition(allMessages, length)
+    expect(result.messages.length).toBe(1)
+    expect(result.overflow.length).toBe(3)
+  })
+  it('should partially overflow with max after msg2', () => {
+    const length = message1.length + message2.length + 1
+    const result = partition(allMessages, length)
+    expect(result.messages.length).toBe(2)
+    expect(result.overflow.length).toBe(2)
+  })
+  it('should partially overflow with max after msg3', () => {
+    const length = message1.length + message2.length + message3.length + 1
+    const result = partition(allMessages, length)
+    expect(result.messages.length).toBe(3)
+    expect(result.overflow.length).toBe(1)
+  })
+  it('should not overflow with max after msg4', () => {
+    const length = message1.length + message2.length + message3.length + message4.length + 1
+    const result = partition(allMessages, length)
+    expect(result.messages.length).toBe(4)
+    expect(result.overflow.length).toBe(0)
+  })
 })

--- a/libs/ai-thread/ai-thread.helpers.test.ts
+++ b/libs/ai-thread/ai-thread.helpers.test.ts
@@ -1,0 +1,36 @@
+import { MessageEvent } from '@coday/coday-events'
+import { partition } from '@coday/ai-thread/ai-thread.helpers'
+
+const message1 = new MessageEvent({ role: 'user', name: 'joe', content: 'hello' })
+const message2 = new MessageEvent({ role: 'assistant', name: 'HAL', content: 'Hi, how are you ?' })
+const message3 = new MessageEvent({ role: 'user', name: 'joe', content: 'HAL, you need to sleep.' })
+const message4 = new MessageEvent({ role: 'assistant', name: 'HAL', content: 'How dare you, meatbag !!' })
+const allMessages = [message1, message2, message3, message4]
+
+describe('partition', () => {
+  it('should handle empty message list', () => {
+    const result = partition([], undefined)
+    expect(result.messages.length).toBe(0)
+    expect(result.overflow.length).toBe(0)
+  })
+  it('should handle single message list', () => {
+    const result = partition([message1], undefined)
+    expect(result.messages.length).toBe(1)
+    expect(result.overflow.length).toBe(0)
+  })
+  it('should handle single message list and overflow', () => {
+    const result = partition([message1], 1)
+    expect(result.messages.length).toBe(0)
+    expect(result.overflow.length).toBe(1)
+  })
+  it('should not overflow without max', () => {
+    const result = partition(allMessages, undefined)
+    expect(result.messages.length).toBe(4)
+    expect(result.overflow.length).toBe(0)
+  })
+  it('should fully overflow with max at 1', () => {
+    const result = partition(allMessages, 1)
+    expect(result.messages.length).toBe(0)
+    expect(result.overflow.length).toBe(4)
+  })
+})

--- a/libs/ai-thread/ai-thread.helpers.test.ts
+++ b/libs/ai-thread/ai-thread.helpers.test.ts
@@ -1,5 +1,5 @@
 import { MessageEvent } from '@coday/coday-events'
-import { partition } from '@coday/ai-thread/ai-thread.helpers'
+import { partition } from './ai-thread.helpers'
 
 const message1 = new MessageEvent({ role: 'user', name: 'joe', content: 'hello' })
 const message2 = new MessageEvent({ role: 'assistant', name: 'HAL', content: 'Hi, how are you ?' })

--- a/libs/ai-thread/ai-thread.helpers.ts
+++ b/libs/ai-thread/ai-thread.helpers.ts
@@ -7,31 +7,16 @@ export function partition(
   messages: ThreadMessage[]
   overflow: ThreadMessage[]
 } {
-  if (!charBudget) return { messages, overflow: [] }
+  if (!charBudget || !messages.length) return { messages, overflow: [] }
   let overflowIndex = 0
   let count = 0
   while (count < charBudget && overflowIndex < messages.length) {
     count += messages[overflowIndex].length
-    overflowIndex++
+    overflowIndex += count < charBudget ? 1 : 0
   }
 
-  console.log('partition: overflowIndex', overflowIndex)
-  if (!overflowIndex) {
-    // then all is overflow
-    console.log('partition: all is overflow')
-    return { messages: [], overflow: messages }
-  }
-  if (overflowIndex === messages.length) {
-    console.log('partition: all is message')
-    return {
-      messages,
-      overflow: [],
-    }
-  }
-
-  const underflow = messages.slice(0, overflowIndex + 1)
+  const underflow = messages.slice(0, overflowIndex)
   const overflow = messages.slice(overflowIndex)
-  console.log('partition overflow', overflow.length, 'underflow', underflow.length)
   return {
     messages: underflow,
     overflow,

--- a/libs/ai-thread/ai-thread.helpers.ts
+++ b/libs/ai-thread/ai-thread.helpers.ts
@@ -1,4 +1,4 @@
-import { ThreadMessage } from '@coday/ai-thread/ai-thread.types'
+import { ThreadMessage } from './ai-thread.types'
 
 export function partition(
   messages: ThreadMessage[],

--- a/libs/ai-thread/ai-thread.helpers.ts
+++ b/libs/ai-thread/ai-thread.helpers.ts
@@ -1,0 +1,39 @@
+import { ThreadMessage } from '@coday/ai-thread/ai-thread.types'
+
+export function partition(
+  messages: ThreadMessage[],
+  charBudget: number | undefined
+): {
+  messages: ThreadMessage[]
+  overflow: ThreadMessage[]
+} {
+  if (!charBudget) return { messages, overflow: [] }
+  let overflowIndex = 0
+  let count = 0
+  while (count < charBudget && overflowIndex < messages.length) {
+    count += messages[overflowIndex].length
+    overflowIndex++
+  }
+
+  console.log('partition: overflowIndex', overflowIndex)
+  if (!overflowIndex) {
+    // then all is overflow
+    console.log('partition: all is overflow')
+    return { messages: [], overflow: messages }
+  }
+  if (overflowIndex === messages.length) {
+    console.log('partition: all is message')
+    return {
+      messages,
+      overflow: [],
+    }
+  }
+
+  const underflow = messages.slice(0, overflowIndex + 1)
+  const overflow = messages.slice(overflowIndex)
+  console.log('partition overflow', overflow.length, 'underflow', underflow.length)
+  return {
+    messages: underflow,
+    overflow,
+  }
+}

--- a/libs/ai-thread/ai-thread.ts
+++ b/libs/ai-thread/ai-thread.ts
@@ -8,6 +8,7 @@ import { buildCodayEvent, MessageEvent, ToolRequestEvent, ToolResponseEvent } fr
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { ToolCall, ToolResponse } from '../integration/tool-call'
 import { EmptyUsage, RunStatus, ThreadMessage, ThreadSerialized, Usage } from './ai-thread.types'
+import { partition } from '@coday/ai-thread/ai-thread.helpers'
 
 /**
  * Allowed message types for filtering when building thread history
@@ -87,43 +88,66 @@ export class AiThread {
   }
 
   /**
-   * Returns a copy of all messages in the thread.
-   * @returns Array of thread messages in chronological order
+   * Returns a partition of the messages regarding the charBudget.
+   * `messages` contains the last messages that fit under the charBudget.
+   * `overflow` contains the first messages that make the conversation overflow the charBudget.
+   * Both are chronolically ordered.
+   * @param maxChars Maximum character limit for the returned messages
+   * @returns an object with truncated messages and those that overflow
    */
-  getMessages(maxChars?: number): ThreadMessage[] {
-    if (!maxChars) return [...this.messages]
+  async getMessages(
+    maxChars: number | undefined,
+    compactor: undefined | ((msgs: ThreadMessage[]) => Promise<ThreadMessage>)
+  ): Promise<{
+    messages: ThreadMessage[]
+    compacted: boolean
+  }> {
+    if (!maxChars) return { messages: [...this.messages], compacted: false }
 
-    const totalChars = this.messages.reduce((count, msg) => count + msg.length, 0)
-    if (totalChars < maxChars) return [...this.messages]
+    console.log('🐼', this.messages.length, 'maxChars', maxChars)
 
-    console.warn(`Truncating context, got ${totalChars} > ${maxChars} allowed chars.`)
-    // Then need to check if still under the limit
-    const firstUserMessageIndex = this.messages.findIndex((msg) => msg instanceof MessageEvent && msg.role === 'user')
-    const limit = maxChars - this.messages[firstUserMessageIndex].length
+    // from the end (hence the toReversed), take all messages that fit into the charbudget
+    let { messages, overflow } = partition(this.messages.toReversed(), maxChars)
+    messages = messages.toReversed()
+    overflow = overflow.toReversed()
 
-    let index = this.messages.length - 1
-    let lastAssistantAnswerIndex = this.messages.length - 1
-    let count = 0
-    while (count < limit && index > firstUserMessageIndex) {
-      const msg = this.messages[index]
-      // update the count
-      count += msg.length
-
-      if (count < limit && msg instanceof MessageEvent && msg.role === 'assistant') {
-        // track the oldest assistant response that fits in the context window
-        lastAssistantAnswerIndex = index
+    // loop into the accepted message to catch all the tool responses without tool requests
+    // this can break the API, so move these lone tool responses into the overflow section instead
+    const messageIds: Set<string> = new Set(messages.map((m) => m.timestamp))
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i]
+      if (message instanceof ToolResponseEvent && messageIds.has(message.toolRequestId)) {
+        console.log(`moving message ${message.timestamp} - ${message.type} to overflow`)
+        messages.splice(i, 1)
+        overflow.push(message)
       }
-
-      index--
+      // ignore other weird cases like a tool request without a response, the thread is either broken or oblivious to that
     }
 
-    // truncate the messages to keep until firstUserMessage included, and from lastAssistantAnswerIndex up to the end
-    const truncated = [
-      ...this.messages.slice(0, firstUserMessageIndex + 1),
-      ...this.messages.slice(lastAssistantAnswerIndex),
-    ]
+    if (!compactor) {
+      // IMPORTANT: apply compaction to the thread to avoid re-doing it all over for every LLM call.
+      this.messages = messages
+      return { messages, compacted: true }
+    }
 
-    return truncated
+    // time to compact, with the same charBudget
+    // overflow itself can be larger than the charBudget, so need to iteratively summarize
+    let summary: ThreadMessage | undefined
+    while (overflow.length) {
+      console.log('overflow reduction', overflow.length)
+      const overflowPartition = partition(overflow, maxChars)
+      console.log('partition', overflowPartition.messages.length, overflowPartition.overflow.length)
+      summary = await compactor(overflowPartition.messages)
+      console.log('summary content', (summary as MessageEvent).content)
+      overflow = overflowPartition.overflow.length ? [summary, ...overflowPartition.overflow] : []
+    }
+    // IMPORTANT: apply compaction to the thread to avoid re-doing it all over for every LLM call.
+    this.messages = summary ? [summary, ...messages] : messages
+
+    return {
+      messages,
+      compacted: true,
+    }
   }
 
   /**

--- a/libs/ai-thread/ai-thread.ts
+++ b/libs/ai-thread/ai-thread.ts
@@ -8,7 +8,7 @@ import { buildCodayEvent, MessageEvent, ToolRequestEvent, ToolResponseEvent } fr
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { ToolCall, ToolResponse } from '../integration/tool-call'
 import { EmptyUsage, RunStatus, ThreadMessage, ThreadSerialized, Usage } from './ai-thread.types'
-import { partition } from '@coday/ai-thread/ai-thread.helpers'
+import { partition } from './ai-thread.helpers'
 
 /**
  * Allowed message types for filtering when building thread history

--- a/libs/ai-thread/ai-thread.types.ts
+++ b/libs/ai-thread/ai-thread.types.ts
@@ -2,7 +2,6 @@
  * @fileoverview Type definitions for thread-related structures
  */
 
-// eslint-disable-next-line @nx/enforce-module-boundaries
 import { MessageEvent, ToolRequestEvent, ToolResponseEvent } from '@coday/coday-events'
 
 /**

--- a/libs/coday.ts
+++ b/libs/coday.ts
@@ -129,7 +129,7 @@ export class Coday {
       if (thread) thread.runStatus = RunStatus.RUNNING
 
       // add the user command to the queue and let handlers decompose it in many and resolve them ultimately
-      this.context.addCommands(userCommand!)
+      this.context?.addCommands(userCommand!)
 
       try {
         this.context = await this.handlerLooper!.handle(this.context)

--- a/libs/coday.ts
+++ b/libs/coday.ts
@@ -1,6 +1,6 @@
 import { AiThread } from './ai-thread/ai-thread'
 import { AiThreadService } from './ai-thread/ai-thread.service'
-import { RunStatus } from './ai-thread/ai-thread.types'
+import { RunStatus, ThreadMessage } from './ai-thread/ai-thread.types'
 import { AiThreadRepositoryFactory } from './ai-thread/repository/ai-thread.repository.factory'
 import { AiHandler, ConfigHandler } from './handler'
 import { HandlerLooper } from './handler-looper'
@@ -56,8 +56,8 @@ export class Coday {
   /**
    * Replay messages from an AiThread through the interactor
    */
-  private replayThread(aiThread: AiThread): void {
-    const messages = aiThread.getMessages()
+  private async replayThread(aiThread: AiThread): Promise<void> {
+    const messages: ThreadMessage[] = (await aiThread.getMessages(undefined, undefined)).messages
     if (!messages?.length) return
     // Sort messages by timestamp to maintain chronological order
     const sortedMessages = [...messages].sort(

--- a/libs/function/find-files-by-name.ts
+++ b/libs/function/find-files-by-name.ts
@@ -18,7 +18,6 @@ export const findFilesByName = async ({ text, path, root, interactor, timeout, l
 
   const expression = `${path ? tweakedPath + '/' : ''}**/*${text}*`
 
-  interactor?.displayText(`Looking for "${expression}" in ${root}`)
   const results = await glob(expression, {
     cwd: root,
     absolute: false,
@@ -27,7 +26,6 @@ export const findFilesByName = async ({ text, path, root, interactor, timeout, l
     signal: AbortSignal.timeout(timeout || defaultTimeout),
     ignore: ['**/node_modules/**', '**/build/**'],
   })
-  interactor?.displayText(`Found ${results.length} files.`)
 
   return !limit || results.length < limit
     ? results

--- a/libs/function/run-bash.ts
+++ b/libs/function/run-bash.ts
@@ -42,7 +42,7 @@ export const runBash = async ({
     const resolvedPath = relPath ? path.resolve(root, relPath) : root
 
     // Log the command that will run
-    interactor.displayText(`\nRunning command: ${command} in ${resolvedPath}`)
+    interactor.debug(`\nRunning command: ${command} in ${resolvedPath}`)
 
     // If confirmation is required, ask for it
     if (requireConfirmation) {
@@ -50,7 +50,6 @@ export const runBash = async ({
         `\nPlease type the reason to reject this command (nothing = validate)`
       )
       if (rejectReason) {
-        interactor.displayText('Command execution was cancelled by user.')
         return `Command execution was cancelled by user with following reason: ${rejectReason}`
       }
     }

--- a/libs/function/run-bash.ts
+++ b/libs/function/run-bash.ts
@@ -6,10 +6,13 @@ import * as path from 'path'
 const execAsync = promisify(exec)
 
 const DEFAULT_LINE_LIMIT = 1000
+const DEFAULT_CHAR_LIMIT = 50000
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024 // 10MB buffer
 
 const limitOutputLines = (output: string, limit: number): string => {
-  const lines = output.split('\n')
+  const truncated = output.length > DEFAULT_CHAR_LIMIT ? output.slice(-DEFAULT_CHAR_LIMIT) : output
+
+  const lines = truncated.split('\n')
   if (lines.length > limit) {
     return lines.slice(-limit).join('\n')
   }

--- a/libs/handler/generate-thread-name.ts
+++ b/libs/handler/generate-thread-name.ts
@@ -4,8 +4,7 @@ import { MessageEvent } from '@coday/coday-events'
 
 export async function generateThreadName(thread: AiThread, agent: Agent): Promise<string> {
   // Extract context from first few user messages
-  const messages = thread
-    .getMessages()
+  const messages = (await thread.getMessages(undefined, undefined)).messages
     .filter((msg) => msg instanceof MessageEvent && msg.role === 'user')
     .slice(0, 3)
     .map((msg) => (msg as MessageEvent).content)

--- a/libs/handler/google.client.ts
+++ b/libs/handler/google.client.ts
@@ -5,7 +5,7 @@ import { CodayLogger } from '../service/coday-logger'
 export class GoogleClient extends OpenaiClient {
   models = [
     {
-      name: 'gemini-2.5-pro-preview-05-06',
+      name: 'gemini-2.5-pro',
       contextWindow: 1000000,
       alias: 'BIG',
       price: {
@@ -15,7 +15,7 @@ export class GoogleClient extends OpenaiClient {
       },
     },
     {
-      name: 'gemini-2.0-flash',
+      name: 'gemini-2.5-flash',
       alias: 'SMALL',
       contextWindow: 1000000,
       price: {

--- a/libs/integration/ai/ai.tools.ts
+++ b/libs/integration/ai/ai.tools.ts
@@ -29,8 +29,14 @@ export class AiTools extends AssistantToolFactory {
         type: 'function',
         function: {
           name: 'queryUser',
-          description:
-            'Allows to ask the user a question. If no options are provided, the user can answer with free text. If options are provided, the user will have to choose a single option. IMPORTANT: Use this tool only when necessary, as it interrupts the flow of execution to seek user input. AVOID closed options unless the user explicitly needs to choose between specific technical alternatives (like file selection, configuration choices, etc.). Prefer open-ended questions to allow natural, nuanced responses.',
+          description: `Allows to ask the user a question.
+
+If no options are provided, the user can answer with free text.
+If options are provided, the user will have to choose a single option.
+
+IMPORTANT: Use this tool only when necessary, as it interrupts the flow of execution to seek user input.
+
+AVOID closed options unless the user explicitly needs to choose between specific technical alternatives (like file selection, configuration choices, etc.). Prefer open-ended questions to allow natural, nuanced responses.`,
           parameters: {
             type: 'object',
             properties: {

--- a/libs/integration/ai/ai.tools.ts
+++ b/libs/integration/ai/ai.tools.ts
@@ -30,13 +30,13 @@ export class AiTools extends AssistantToolFactory {
         function: {
           name: 'queryUser',
           description: `Allows to ask the user a question.
+IMPORTANT: Use this tool only when necessary, as it is intrusive for the user.
 
 If no options are provided, the user can answer with free text.
 If options are provided, the user will have to choose a single option.
 
-IMPORTANT: Use this tool only when necessary, as it interrupts the flow of execution to seek user input.
-
 AVOID closed options unless the user explicitly needs to choose between specific technical alternatives (like file selection, configuration choices, etc.). Prefer open-ended questions to allow natural, nuanced responses.`,
+
           parameters: {
             type: 'object',
             properties: {

--- a/libs/integration/file/unlink-file.ts
+++ b/libs/integration/file/unlink-file.ts
@@ -1,10 +1,9 @@
-import fs from 'fs'
+import * as fs from 'fs'
 import { promisify } from 'util'
 import { Interactor } from '../../model'
 
 const unlink = promisify(fs.unlink)
 
 export async function unlinkFile(filePath: string, interactor: Interactor): Promise<void> {
-  interactor.displayText(`Removing file ${filePath}`)
   await unlink(filePath)
 }

--- a/libs/integration/file/write-file-by-path.ts
+++ b/libs/integration/file/write-file-by-path.ts
@@ -19,7 +19,7 @@ export const writeFileByPath = ({ relPath, root, interactor, content }: WriteFil
   try {
     const dir = path.dirname(fullPath)
     if (!existsSync(dir)) {
-      interactor?.displayText(`Making directory ${dir}`)
+      interactor?.debug(`Making directory ${dir}`)
       mkdirSync(dir, { recursive: true })
     }
 
@@ -32,7 +32,6 @@ export const writeFileByPath = ({ relPath, root, interactor, content }: WriteFil
       }
     }
 
-    interactor?.displayText(`Writing file ${fullPath}`)
     const data = new Uint8Array(Buffer.from(content))
     writeFileSync(fullPath, data)
     return 'File write success'

--- a/libs/integration/projectScriptsTools.ts
+++ b/libs/integration/projectScriptsTools.ts
@@ -29,7 +29,7 @@ export class ProjectScriptsTools extends AssistantToolFactory {
               command: commandWithParams,
               root: context.project.root,
               interactor: this.interactor,
-              requireConfirmation: false,
+              requireConfirmation: entry[1].requireConfirmation,
             })
           }
           const scriptFunction: FunctionTool<unknown> = {

--- a/libs/integration/toolbox.ts
+++ b/libs/integration/toolbox.ts
@@ -59,7 +59,7 @@ export class Toolbox implements Killable {
             const tools = await factory.getTools(context, integrations?.get(factory.name) ?? [], agentName ?? 'default')
             return tools
           } catch (error) {
-            this.interactor.error(`Error building tools from ${factory.name} for agent ${agentName}: ${error}`)
+            this.interactor.debug(`Error building tools from ${factory.name} for agent ${agentName}: ${error}`)
             // Return empty array if a specific factory fails
             return []
           }
@@ -69,7 +69,7 @@ export class Toolbox implements Killable {
       this.tools = toolResults.flat()
       return this.tools
     } catch (error) {
-      this.interactor.error(`Unexpected error building tools for agent ${agentName}: ${error}`)
+      this.interactor.debug(`Unexpected error building tools for agent ${agentName}: ${error}`)
       // Return empty array in case of critical failure
       return []
     }

--- a/libs/model/ai.client.ts
+++ b/libs/model/ai.client.ts
@@ -2,7 +2,7 @@ import { Observable, of, Subject } from 'rxjs'
 import { CodayEvent, ErrorEvent, MessageEvent, ToolRequestEvent, ToolResponseEvent } from '@coday/coday-events'
 import { Agent } from './agent'
 import { AiThread } from '../ai-thread/ai-thread'
-import { RunStatus } from '../ai-thread/ai-thread.types'
+import { RunStatus, ThreadMessage } from '../ai-thread/ai-thread.types'
 import { Interactor } from './interactor'
 import { AiModel } from './ai-model'
 import { AiProviderConfig } from './ai-provider-config'
@@ -67,6 +67,55 @@ export abstract class AiClient {
    */
   kill(): void {
     this.killed = true
+  }
+
+  private getCompactor(model: string, maxChars: number): (messages: ThreadMessage[]) => Promise<ThreadMessage> {
+    return async (messages: ThreadMessage[]): Promise<ThreadMessage> => {
+      const transcript = messages
+        // without the tool request and response, hypothesis is we can do without and simply the "text"
+        .filter((m) => m instanceof MessageEvent)
+        .map((m) => ` - ${m.role}: ${m.content}`)
+        .join('\n')
+
+      const firstUserMessage = messages.find((m) => m instanceof MessageEvent && m.role === 'user')
+
+      const prompt = `Here is a transcript of a conversation:
+<transcript>${transcript}</transcript>
+
+It can be summarized as:
+<summary>
+`
+      let summary = '...previous conversation compacted'
+      try {
+        summary = await this.complete(prompt, {
+          model,
+          maxTokens: Math.floor(maxChars / 20),
+          stopSequences: ['</summary>'],
+        })
+        this.interactor.debug(`Compacted ${messages.length} messages into ${summary.length} chars summary.`)
+      } catch (e) {
+        this.interactor.warn('Could not compact properly the conversation, truncated beginning instead.')
+      }
+
+      // then make summary the first message
+      return new MessageEvent({
+        role: 'user',
+        name: firstUserMessage ? (firstUserMessage as MessageEvent).name : 'user',
+        content: summary,
+      })
+    }
+  }
+
+  protected async getMessages(
+    thread: AiThread,
+    charBudget: number,
+    model: string
+  ): Promise<{
+    messages: ThreadMessage[]
+    compacted: boolean
+  }> {
+    const compactor = this.getCompactor(model)
+    return await thread.getMessages(charBudget, compactor)
   }
 
   /**

--- a/libs/model/ai.client.ts
+++ b/libs/model/ai.client.ts
@@ -79,21 +79,24 @@ export abstract class AiClient {
 
       const firstUserMessage = messages.find((m) => m instanceof MessageEvent && m.role === 'user')
 
+      const summaryBudget = Math.floor(maxChars / 20)
+
       const prompt = `Here is a transcript of a conversation:
 <transcript>${transcript}</transcript>
 
 It can be summarized as:
 <summary>
 `
-      let summary = '...previous conversation compacted'
+      let summary: string
       try {
         summary = await this.complete(prompt, {
           model,
-          maxTokens: Math.floor(maxChars / 20),
+          maxTokens: summaryBudget,
           stopSequences: ['</summary>'],
         })
         this.interactor.debug(`Compacted ${messages.length} messages into ${summary.length} chars summary.`)
       } catch (e) {
+        summary = '...previous conversation truncated'
         this.interactor.warn('Could not compact properly the conversation, truncated beginning instead.')
       }
 
@@ -114,7 +117,7 @@ It can be summarized as:
     messages: ThreadMessage[]
     compacted: boolean
   }> {
-    const compactor = this.getCompactor(model)
+    const compactor = this.getCompactor(model, charBudget)
     return await thread.getMessages(charBudget, compactor)
   }
 

--- a/libs/model/ai.client.ts
+++ b/libs/model/ai.client.ts
@@ -25,7 +25,7 @@ export abstract class AiClient {
   protected abstract interactor: Interactor
   protected killed: boolean = false
   protected thinkingInterval: number = 3000
-  protected charsPerToken: number = 3.5 // should be 4, some margin baked in to avoid overshoot on tool call
+  protected charsPerToken: number = 3 // should be 4, some margin baked in to avoid overshoot on tool call
   protected username?: string
 
   protected constructor(
@@ -97,6 +97,7 @@ It can be summarized as:
         this.interactor.debug(`Compacted ${messages.length} messages into ${summary.length} chars summary.`)
       } catch (e) {
         summary = '...previous conversation truncated'
+        console.error(e)
         this.interactor.warn('Could not compact properly the conversation, truncated beginning instead.')
       }
 

--- a/libs/model/scripts.ts
+++ b/libs/model/scripts.ts
@@ -18,6 +18,8 @@ type Script = {
    * Be extensive in describing what are the arguments, the order, meaning and connection to the command line.
    */
   parametersDescription?: string
+
+  requireConfirmation?: boolean
 }
 
 /**

--- a/libs/utils/output-limiter.test.ts
+++ b/libs/utils/output-limiter.test.ts
@@ -1,0 +1,134 @@
+import { 
+  limitOutput, 
+  limitOutputLines, 
+  limitOutputChars,
+  DEFAULT_LINE_LIMIT,
+  DEFAULT_CHAR_LIMIT 
+} from './output-limiter'
+
+describe('Output Limiter', () => {
+  
+  describe('limitOutputLines', () => {
+    it('should return original output when line count is within limit', () => {
+      const output = 'line1\nline2\nline3'
+      const result = limitOutputLines(output, 5)
+      expect(result).toBe(output)
+    })
+
+    it('should keep last N lines when exceeding limit', () => {
+      const output = 'line1\nline2\nline3\nline4\nline5'
+      const result = limitOutputLines(output, 3)
+      expect(result).toBe('line3\nline4\nline5')
+    })
+
+    it('should handle single line output', () => {
+      const output = 'single line'
+      const result = limitOutputLines(output, 1)
+      expect(result).toBe(output)
+    })
+
+    it('should handle empty output', () => {
+      const output = ''
+      const result = limitOutputLines(output, 10)
+      expect(result).toBe('')
+    })
+
+    it('should handle output with only newlines', () => {
+      const output = '\n\n\n'
+      const result = limitOutputLines(output, 2)
+      // When splitting '\n\n\n' by '\n', we get ['', '', '', ''] (4 empty strings)
+      // Taking the last 2 elements gives ['', ''] which joined becomes '\n'
+      expect(result).toBe('\n')
+    })
+  })
+
+  describe('limitOutputChars', () => {
+    it('should return original output when char count is within limit', () => {
+      const output = 'short text'
+      const result = limitOutputChars(output, 20)
+      expect(result).toBe(output)
+    })
+
+    it('should keep last N characters when exceeding limit', () => {
+      const output = 'this is a very long text that should be truncated'
+      const result = limitOutputChars(output, 20)
+      expect(result).toBe(' should be truncated')
+    })
+
+    it('should handle empty output', () => {
+      const output = ''
+      const result = limitOutputChars(output, 10)
+      expect(result).toBe('')
+    })
+
+    it('should handle exact limit', () => {
+      const output = 'exactly20characters!'
+      const result = limitOutputChars(output, 20)
+      expect(result).toBe(output)
+    })
+  })
+
+  describe('limitOutput', () => {
+    it('should apply both line and character limits', () => {
+      const output = 'line1\nline2\nline3\nline4\nline5'
+      const result = limitOutput(output, { lineLimit: 3, charLimit: 100 })
+      expect(result).toBe('line3\nline4\nline5')
+    })
+
+    it('should prioritize character limit when both limits are exceeded', () => {
+      const output = 'very long line 1\nvery long line 2\nvery long line 3\nvery long line 4'
+      const result = limitOutput(output, { lineLimit: 5, charLimit: 30 })
+      // Should first truncate by chars (last 30), then by lines
+      expect(result.length).toBeLessThanOrEqual(30)
+    })
+
+    it('should handle case where character limit creates fewer lines than line limit', () => {
+      const longOutput = Array(10).fill('line with some content').join('\n')
+      const result = limitOutput(longOutput, { lineLimit: 8, charLimit: 50 })
+      
+      // Character limit should be applied first, potentially reducing line count
+      expect(result.length).toBeLessThanOrEqual(50)
+      const resultLines = result.split('\n')
+      expect(resultLines.length).toBeLessThanOrEqual(8)
+    })
+
+    it('should return original when within both limits', () => {
+      const output = 'line1\nline2'
+      const result = limitOutput(output, { lineLimit: 5, charLimit: 100 })
+      expect(result).toBe(output)
+    })
+  })
+
+  describe('Default constants', () => {
+    it('should have reasonable default values', () => {
+      expect(DEFAULT_LINE_LIMIT).toBe(1000)
+      expect(DEFAULT_CHAR_LIMIT).toBe(50000)
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle very large inputs efficiently', () => {
+      const largeOutput = Array(10000).fill('test line').join('\n')
+      const start = Date.now()
+      const result = limitOutput(largeOutput, { lineLimit: 100, charLimit: 5000 })
+      const duration = Date.now() - start
+      
+      expect(duration).toBeLessThan(100) // Should be fast
+      expect(result.split('\n').length).toBeLessThanOrEqual(100)
+      expect(result.length).toBeLessThanOrEqual(5000)
+    })
+
+    it('should handle unicode characters correctly', () => {
+      const output = '🚀 ligne 1\n🎯 ligne 2\n✨ ligne 3'
+      const result = limitOutputLines(output, 2)
+      expect(result).toBe('🎯 ligne 2\n✨ ligne 3')
+    })
+
+    it('should handle mixed line endings', () => {
+      const output = 'line1\r\nline2\nline3\r\nline4'
+      const result = limitOutputLines(output, 2)
+      // Should work with \n splits, \r characters will be preserved
+      expect(result.split('\n').length).toBe(2)
+    })
+  })
+})

--- a/libs/utils/output-limiter.ts
+++ b/libs/utils/output-limiter.ts
@@ -1,0 +1,55 @@
+/**
+ * Utility functions for limiting output size and line count
+ */
+
+export interface OutputLimiterOptions {
+  /** Maximum number of lines to keep (keeps the last N lines) */
+  lineLimit: number
+  /** Maximum number of characters to keep (keeps the last N characters) */
+  charLimit: number
+}
+
+/**
+ * Limits the output by both character count and line count
+ *
+ * @param output The text output to limit
+ * @param options Configuration for limiting behavior
+ * @returns The limited output string
+ */
+export const limitOutput = (output: string, options: OutputLimiterOptions): string => {
+  const { lineLimit, charLimit } = options
+
+  const truncated = limitOutputChars(output, charLimit)
+
+  return limitOutputLines(truncated, lineLimit)
+}
+
+/**
+ * Limits the output by line count only
+ *
+ * @param output The text output to limit
+ * @param lineLimit Maximum number of lines to keep (keeps the last N lines)
+ * @returns The limited output string
+ */
+export const limitOutputLines = (output: string, lineLimit: number): string => {
+  const lines = output.split('\n')
+  if (lines.length > lineLimit) {
+    return lines.slice(-lineLimit).join('\n')
+  }
+  return output
+}
+
+/**
+ * Limits the output by character count only
+ *
+ * @param output The text output to limit
+ * @param charLimit Maximum number of characters to keep (keeps the last N characters)
+ * @returns The limited output string
+ */
+export const limitOutputChars = (output: string, charLimit: number): string => {
+  return output.length > charLimit ? output.slice(-charLimit) : output
+}
+
+// Default constants
+export const DEFAULT_LINE_LIMIT = 1000
+export const DEFAULT_CHAR_LIMIT = 50000


### PR DESCRIPTION
Fix the context window management by:
- partitionning the thread into kept messages and an overflow
- handling the overflow by summarizing it (or truncating if not possible)

Results: less contextWindow overflow, but still some cases tied to super long tool outputs, still observing...

Caveats:
- Compaction is persisted: calling a short-contextwindow-model will compact the thread even for later bigger models
- Last model used is the one doing the compaction

Various life-improvements too:
- tab title = selected project
- corner case error on resume thread
- restrict the run-bash output by char before counting lines
- reformat queryUser description for less queryUser obsession
- allow `requireConfirmation` on project scripts
- mcp creation errors in debug
- thread cleanup removes un-parseable files